### PR TITLE
A few UIKit extensions

### DIFF
--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		D834573C1AFEE57E0070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
 		D834573D1AFEE57E0070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
 		D83457411AFEE6050070616A /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
+		D86FFBD11B34AD6F001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
+		D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
 		D8F0973B1B17F2F7002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
 		D8F0973D1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
 		D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
@@ -113,6 +115,7 @@
 		D86E77AA1AFEE646004BF23D /* RexTests-Mac.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-Mac.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86E77AB1AFEE646004BF23D /* Rex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86E77AC1AFEE646004BF23D /* RexTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D86FFBD01B34AD6F001A89B3 /* Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Association.swift; sourceTree = "<group>"; };
 		D8F0973A1B17F2F7002E15BA /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
 		D8F097431B17F3C8002E15BA /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
@@ -253,6 +256,7 @@
 		D8F097391B17F2BF002E15BA /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				D86FFBD01B34AD6F001A89B3 /* Association.swift */,
 				D8F0973A1B17F2F7002E15BA /* NSData.swift */,
 				D8F097431B17F3C8002E15BA /* NSObject.swift */,
 				D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */,
@@ -443,6 +447,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8F0974D1B190ECE002E15BA /* Property.swift in Sources */,
+				D86FFBD11B34AD6F001A89B3 /* Association.swift in Sources */,
 				D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */,
 				7DE995CB1B03A56800CA9420 /* Operators.swift in Sources */,
 				D8003EBD1AFED01000D7D3C5 /* Signal.swift in Sources */,
@@ -468,6 +473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8F0974E1B190ECE002E15BA /* Property.swift in Sources */,
+				D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */,
 				D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */,
 				D834572D1AFEE45B0070616A /* Signal.swift in Sources */,
 				7DE995CC1B03A56800CA9420 /* Operators.swift in Sources */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		D86FFBD11B34AD6F001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
 		D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
 		D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD41B34B0FE001A89B3 /* UIControl.swift */; };
+		D86FFBD81B34B242001A89B3 /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD71B34B242001A89B3 /* UILabel.swift */; };
 		D8F0973B1B17F2F7002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
 		D8F0973D1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
 		D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
@@ -118,6 +119,7 @@
 		D86E77AC1AFEE646004BF23D /* RexTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86FFBD01B34AD6F001A89B3 /* Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Association.swift; sourceTree = "<group>"; };
 		D86FFBD41B34B0FE001A89B3 /* UIControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControl.swift; sourceTree = "<group>"; };
+		D86FFBD71B34B242001A89B3 /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
 		D8F0973A1B17F2F7002E15BA /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
 		D8F097431B17F3C8002E15BA /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
@@ -260,6 +262,7 @@
 			isa = PBXGroup;
 			children = (
 				D86FFBD41B34B0FE001A89B3 /* UIControl.swift */,
+				D86FFBD71B34B242001A89B3 /* UILabel.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -483,6 +486,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D86FFBD81B34B242001A89B3 /* UILabel.swift in Sources */,
 				D8F0974E1B190ECE002E15BA /* Property.swift in Sources */,
 				D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */,
 				D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
 		D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD41B34B0FE001A89B3 /* UIControl.swift */; };
 		D86FFBD81B34B242001A89B3 /* UILabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD71B34B242001A89B3 /* UILabel.swift */; };
+		D86FFBDA1B34B3F0001A89B3 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD91B34B3F0001A89B3 /* Action.swift */; };
+		D86FFBDB1B34B3F0001A89B3 /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD91B34B3F0001A89B3 /* Action.swift */; };
+		D86FFBDD1B34B691001A89B3 /* UIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBDC1B34B691001A89B3 /* UIButton.swift */; };
 		D8F0973B1B17F2F7002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
 		D8F0973D1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
 		D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
@@ -120,6 +123,8 @@
 		D86FFBD01B34AD6F001A89B3 /* Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Association.swift; sourceTree = "<group>"; };
 		D86FFBD41B34B0FE001A89B3 /* UIControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControl.swift; sourceTree = "<group>"; };
 		D86FFBD71B34B242001A89B3 /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabel.swift; sourceTree = "<group>"; };
+		D86FFBD91B34B3F0001A89B3 /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
+		D86FFBDC1B34B691001A89B3 /* UIButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButton.swift; sourceTree = "<group>"; };
 		D8F0973A1B17F2F7002E15BA /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
 		D8F097431B17F3C8002E15BA /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
@@ -184,6 +189,7 @@
 		D8003E901AFEC3D400D7D3C5 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				D86FFBD91B34B3F0001A89B3 /* Action.swift */,
 				7DE995CA1B03A56800CA9420 /* Operators.swift */,
 				D8F0974C1B190ECE002E15BA /* Property.swift */,
 				D8003EBC1AFED01000D7D3C5 /* Signal.swift */,
@@ -261,6 +267,7 @@
 		D86FFBD31B34B0E2001A89B3 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				D86FFBDC1B34B691001A89B3 /* UIButton.swift */,
 				D86FFBD41B34B0FE001A89B3 /* UIControl.swift */,
 				D86FFBD71B34B242001A89B3 /* UILabel.swift */,
 			);
@@ -461,6 +468,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8F0974D1B190ECE002E15BA /* Property.swift in Sources */,
+				D86FFBDA1B34B3F0001A89B3 /* Action.swift in Sources */,
 				D86FFBD11B34AD6F001A89B3 /* Association.swift in Sources */,
 				D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */,
 				7DE995CB1B03A56800CA9420 /* Operators.swift in Sources */,
@@ -487,6 +495,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D86FFBD81B34B242001A89B3 /* UILabel.swift in Sources */,
+				D86FFBDB1B34B3F0001A89B3 /* Action.swift in Sources */,
 				D8F0974E1B190ECE002E15BA /* Property.swift in Sources */,
 				D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */,
 				D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */,
@@ -496,6 +505,7 @@
 				D834572E1AFEE45B0070616A /* SignalProducer.swift in Sources */,
 				D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */,
 				D8F0973F1B17F31E002E15BA /* NSData.swift in Sources */,
+				D86FFBDD1B34B691001A89B3 /* UIButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		D83457411AFEE6050070616A /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
 		D86FFBD11B34AD6F001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
 		D86FFBD21B34AD7A001A89B3 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
+		D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD41B34B0FE001A89B3 /* UIControl.swift */; };
 		D8F0973B1B17F2F7002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
 		D8F0973D1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
 		D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
@@ -116,6 +117,7 @@
 		D86E77AB1AFEE646004BF23D /* Rex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86E77AC1AFEE646004BF23D /* RexTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86FFBD01B34AD6F001A89B3 /* Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Association.swift; sourceTree = "<group>"; };
+		D86FFBD41B34B0FE001A89B3 /* UIControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIControl.swift; sourceTree = "<group>"; };
 		D8F0973A1B17F2F7002E15BA /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
 		D8F097431B17F3C8002E15BA /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				D8003EBC1AFED01000D7D3C5 /* Signal.swift */,
 				D8003EB81AFEC7A900D7D3C5 /* SignalProducer.swift */,
 				D8F097391B17F2BF002E15BA /* Foundation */,
+				D86FFBD31B34B0E2001A89B3 /* UIKit */,
 				D8003E911AFEC3D400D7D3C5 /* Supporting Files */,
 			);
 			path = Source;
@@ -251,6 +254,14 @@
 				D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */,
 			);
 			path = iOS;
+			sourceTree = "<group>";
+		};
+		D86FFBD31B34B0E2001A89B3 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				D86FFBD41B34B0FE001A89B3 /* UIControl.swift */,
+			);
+			path = UIKit;
 			sourceTree = "<group>";
 		};
 		D8F097391B17F2BF002E15BA /* Foundation */ = {
@@ -479,6 +490,7 @@
 				7DE995CC1B03A56800CA9420 /* Operators.swift in Sources */,
 				D8F097451B17F3C8002E15BA /* NSObject.swift in Sources */,
 				D834572E1AFEE45B0070616A /* SignalProducer.swift in Sources */,
+				D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */,
 				D8F0973F1B17F31E002E15BA /* NSData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -1,0 +1,35 @@
+//
+//  Action.swift
+//  Rex
+//
+//  Created by Neil Pankey on 6/19/15.
+//  Copyright (c) 2015 Neil Pankey. All rights reserved.
+//
+
+import ReactiveCocoa
+
+extension Action {
+    /// Creates an always disabled action.
+    static var rex_disabled: Action {
+        return Action(enabledIf: ConstantProperty(false)) { _ in .empty }
+    }
+}
+
+extension CocoaAction {
+    /// Creates an always disabled action that can be used as a default for
+    /// things like `rac_pressed`.
+    public static var rex_disabled: CocoaAction {
+        return CocoaAction(Action<Any?, (), NoError>.rex_disabled, input: nil)
+    }
+
+    /// Creates a producer for the `enabled` state of a CocoaAction.
+    public var rex_enabledProducer: SignalProducer<Bool, NoError> {
+        return rex_producerForKeyPath("enabled")
+    }
+
+    /// Creates a producer for the `executing` state of a CocoaAction.
+    public var rex_executingProducer: SignalProducer<Bool, NoError> {
+        return rex_producerForKeyPath("executing")
+    }
+}
+

--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -1,0 +1,61 @@
+//
+//  Association.swift
+//  Rex
+//
+//  Created by Neil Pankey on 6/19/15.
+//  Copyright (c) 2015 Neil Pankey. All rights reserved.
+//
+
+import ReactiveCocoa
+
+/// Attaches a `MutableProperty` value to the `host` object using KVC to get the initial
+/// value and write subsequent updates from the property's producer. Note that `keyPath`
+/// is a `StaticString` because it's pointer value is used as key value when associating
+/// the property.
+///
+/// This can be used as an alternative to `DynamicProperty` for creating strongly typed
+/// bindings on Cocoa objects.
+public func associatedProperty(host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
+    let initial  = { host.valueForKeyPath(keyPath.stringValue) as? String ?? "" }
+    let setter: String -> () = { host.setValue($0, forKeyPath: keyPath.stringValue) }
+    return associatedProperty(host, keyPath.utf8Start, initial, setter)
+}
+
+/// Attaches a `MutableProperty` value to the `host` object using KVC to get the initial
+/// value and write subsequent updates from the property's producer. Note that `keyPath`
+/// is a `StaticString` because it's pointer value is used as key value when associating
+/// the property.
+///
+/// This can be used as an alternative to `DynamicProperty` for creating strongly typed
+/// bindings on Cocoa objects.
+public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticString, placeholder: () -> T) -> MutableProperty<T> {
+    let initial  = { host.valueForKeyPath(keyPath.stringValue) as? T ?? placeholder() }
+    let setter: T -> () = { host.setValue($0, forKeyPath: keyPath.stringValue) }
+    return associatedProperty(host, keyPath.utf8Start, initial, setter)
+}
+
+/// Attaches a `MutableProperty` value to the `host` object under `key`. The property is
+/// initialized with the result of `initial`. Changes on the property's producer are
+/// monitored and written to `setter`.
+///
+/// This can be used as an alternative to `DynamicProperty` for creating strongly typed
+/// bindings on Cocoa objects.
+public func associatedProperty<T>(host: AnyObject, key: UnsafePointer<()>, initial: () -> T, setter: T -> ()) -> MutableProperty<T> {
+    return associatedObject(host, key) {
+        let property = MutableProperty(initial())
+        property.producer.start(next: setter)
+        return property
+    }
+}
+
+/// On first use attaches the object returned from `initial` to the `host` object
+/// using `key` via `objc_setAssociatedObject`. On subsequent usage, returns said
+/// object via `objc_getAssociatedObject`.
+public func associatedObject<T: AnyObject>(host: AnyObject, key: UnsafePointer<()>, initial: () -> T) -> T {
+    var value = objc_getAssociatedObject(host, key) as? T
+    if value == nil {
+        value = initial()
+        objc_setAssociatedObject(host, key, value, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN))
+    }
+    return value!
+}

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -10,6 +10,10 @@ import ReactiveCocoa
 import UIKit
 
 extension UIButton {
+    /// Exposes a property that binds an action to button presses. The action is set as
+    /// a target of the button for `TouchUpInside` events. When property changes occur the
+    /// previous action is removed as a target. This also binds the enabled state of the
+    /// action to the `rex_enabled` property on the button.
     public var rac_pressed: MutableProperty<CocoaAction> {
         return associatedObject(self, &pressed, { _ in
             let initial = CocoaAction.rex_disabled

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -1,0 +1,31 @@
+//
+//  UIButton.swift
+//  Rex
+//
+//  Created by Neil Pankey on 6/19/15.
+//  Copyright (c) 2015 Neil Pankey. All rights reserved.
+//
+
+import ReactiveCocoa
+import UIKit
+
+extension UIButton {
+    public var rac_pressed: MutableProperty<CocoaAction> {
+        return associatedObject(self, &pressed, { _ in
+            let initial = CocoaAction.rex_disabled
+            let property = MutableProperty(initial)
+
+            property.producer
+                |> combinePrevious(initial)
+                |> start { previous, next in
+                    self.removeTarget(previous, action: CocoaAction.selector, forControlEvents: .TouchUpInside)
+                    self.addTarget(next, action: CocoaAction.selector, forControlEvents: .TouchUpInside)
+            }
+
+            self.rex_enabled <~ property.producer |> flatMap(.Latest) { $0.rex_enabledProducer }
+            return property
+        })
+    }
+}
+
+private var pressed: UInt8 = 0

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -1,0 +1,16 @@
+//
+//  UIView.swift
+//  Rex
+//
+//  Created by Neil Pankey on 6/19/15.
+//  Copyright (c) 2015 Neil Pankey. All rights reserved.
+//
+
+import UIKit
+
+extension UIControl {
+    /// Wraps a control's `enabled` state in a bindable property.
+    public var rex_enabled: MutableProperty<Bool> {
+        return associatedProperty(self, &Keys.enabled, { self.enabled }, { self.enabled = $0 })
+    }
+}

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -12,10 +12,8 @@ import UIKit
 extension UIControl {
     /// Wraps a control's `enabled` state in a bindable property.
     public var rex_enabled: MutableProperty<Bool> {
-        return associatedProperty(self, &Keys.enabled, { self.enabled }, { self.enabled = $0 })
+        return associatedProperty(self, &enabled, { self.enabled }, { self.enabled = $0 })
     }
 }
 
-private struct Keys {
-    static var enabled: UInt8 = 0
-}
+private var enabled: UInt8 = 0

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveCocoa
 import UIKit
 
 extension UIControl {
@@ -13,4 +14,8 @@ extension UIControl {
     public var rex_enabled: MutableProperty<Bool> {
         return associatedProperty(self, &Keys.enabled, { self.enabled }, { self.enabled = $0 })
     }
+}
+
+private struct Keys {
+    static var enabled: UInt8 = 0
 }

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -1,0 +1,14 @@
+//
+//  UILabel.swift
+//  Rex
+//
+//  Created by Neil Pankey on 6/19/15.
+//  Copyright (c) 2015 Neil Pankey. All rights reserved.
+//
+
+extension UILabel {
+    /// Wraps a label's `enabled` state in a bindable property.
+    public var rex_text: MutableProperty<String> {
+        return associatedProperty(self, "text")
+    }
+}

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -6,6 +6,9 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveCocoa
+import UIKit
+
 extension UILabel {
     /// Wraps a label's `enabled` state in a bindable property.
     public var rex_text: MutableProperty<String> {


### PR DESCRIPTION
Exposes some `MutableProperty` extensions that make binding to UIKit from RAC easier without having to resort to `DynamicProperty`.
