### PR TITLE
Make some extension methods public

### DIFF
--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -10,7 +10,7 @@ import ReactiveCocoa
 
 extension Action {
     /// Creates an always disabled action.
-    static var rex_disabled: Action {
+    public static var rex_disabled: Action {
         return Action(enabledIf: ConstantProperty(false)) { _ in .empty }
     }
 }

--- a/Source/Foundation/NSData.swift
+++ b/Source/Foundation/NSData.swift
@@ -12,7 +12,7 @@ import ReactiveCocoa
 extension NSData {
     /// Read the data at the URL.
     /// Sends the data or the error.
-    class func rex_dataWithContentsOfURL(url: NSURL, options: NSDataReadingOptions = NSDataReadingOptions()) -> SignalProducer<NSData, NSError> {
+    public class func rex_dataWithContentsOfURL(url: NSURL, options: NSDataReadingOptions = NSDataReadingOptions()) -> SignalProducer<NSData, NSError> {
         return SignalProducer<NSData, NSError> { observer, disposable in
             do {
                 let data = try NSData(contentsOfURL: url, options: options)

--- a/Source/Foundation/NSUserDefaults.swift
+++ b/Source/Foundation/NSUserDefaults.swift
@@ -14,7 +14,7 @@ extension NSUserDefaults {
     /// by casting to NSObject and checking for equality. If the values aren't
     /// convertible this will generate events whenever _any_ value in NSUserDefaults
     /// changes.
-    func rex_valueForKey(key: String) -> SignalProducer<AnyObject?, NoError> {
+    public func rex_valueForKey(key: String) -> SignalProducer<AnyObject?, NoError> {
         let center = NSNotificationCenter.defaultCenter()
         let initial = objectForKey(key)
 


### PR DESCRIPTION
I'm not sure `Action.rex_disabled` is meant to be public or not.
