### PR TITLE
Remove workarounds for compiler warning about StaticString

### DIFF
--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -17,13 +17,11 @@ import ReactiveCocoa
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
 public func associatedProperty(host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
-    // Workaround compiler warning when using keyPath.stringValue
-    let key = "\(keyPath)"
     let initial: () -> String  = { [weak host] _ in
-        host?.valueForKeyPath(key) as? String ?? ""
+        host?.valueForKeyPath(keyPath.stringValue) as? String ?? ""
     }
     let setter: String -> () = { [weak host] newValue in
-        host?.setValue(newValue, forKeyPath: key)
+        host?.setValue(newValue, forKeyPath: keyPath.stringValue)
     }
     return associatedProperty(host, key: keyPath.utf8Start, initial: initial, setter: setter)
 }
@@ -39,13 +37,11 @@ public func associatedProperty(host: AnyObject, keyPath: StaticString) -> Mutabl
 /// N.B. Ensure that `host` isn't strongly captured by `placeholder`, otherwise this will
 /// create a retain cycle with `host` causing it to never dealloc.
 public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticString, placeholder: () -> T) -> MutableProperty<T> {
-    // Workaround compiler warning when using keyPath.stringValue
-    let key = "\(keyPath)"
     let initial: () -> T  = { [weak host] _ in
-        host?.valueForKeyPath(key) as? T ?? placeholder()
+        host?.valueForKeyPath(keyPath.stringValue) as? T ?? placeholder()
     }
     let setter: T -> () = { [weak host] newValue in
-        host?.setValue(newValue, forKeyPath: key)
+        host?.setValue(newValue, forKeyPath: keyPath.stringValue)
     }
     return associatedProperty(host, key: keyPath.utf8Start, initial: initial, setter: setter)
 }


### PR DESCRIPTION
The compiler warning disappears in Xcode 7.
