### PR TITLE
Boolean Operations [WIP]

### DIFF
--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -124,3 +124,58 @@ extension SignalType where T: BooleanType {
     }
 }
 
+extension SignalType where T: SequenceType, T.Generator.Element: BooleanType {
+    /// Returns a signal that sends `a && b && c && ...` for each value (a, b, c, ...) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func and() -> Signal<Bool, E> {
+        return Signal<Bool, E> { observer in
+            return self.observe { event in
+                switch event {
+                case let .Next(sequence):
+                    sendNext(observer, sequence.reduce(true) { $0.boolValue && $1.boolValue })
+                case let .Error(error):
+                    sendError(observer, error)
+                case .Completed:
+                    sendCompleted(observer)
+                case .Interrupted:
+                    sendInterrupted(observer)
+                }
+            }
+        }
+    }
+
+    /// Returns a signal that sends `a ||& b || c || ...` for each value (a, b, c, ...) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func or() -> Signal<Bool, E> {
+        return Signal<Bool, E> { observer in
+            return self.observe { event in
+                switch event {
+                case let .Next(sequence):
+                    sendNext(observer, sequence.reduce(false) { $0.boolValue || $1.boolValue })
+                case let .Error(error):
+                    sendError(observer, error)
+                case .Completed:
+                    sendCompleted(observer)
+                case .Interrupted:
+                    sendInterrupted(observer)
+                }
+            }
+        }
+    }
+}
+
+extension SignalType where T == (Bool, Bool) {
+    /// Returns a signal that sends `a && b` for each value (a, b) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func and() -> Signal<Bool, E> {
+        return self.map{ [$0.0, $0.1] }.and()
+    }
+    
+    /// Returns a signal that sends `a || b` for each value (a, b) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func or() -> Signal<Bool, E> {
+        return self.map{ [$0.0, $0.1] }.or()
+    }
+}
+
+

--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -109,3 +109,18 @@ extension SignalType where T: SequenceType {
         }
     }
 }
+
+// MARK: Boolean Operations
+
+extension SignalType where T: BooleanType {    
+    /// Returns a signal that inverts each value sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func not() -> Signal<Bool, E> {
+        return Signal { observer in
+            return self.observe { (event: Event<T, E>) in
+                observer(event.map { value in !value })
+            }
+        }
+    }
+}
+

--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -118,7 +118,7 @@ extension SignalType where T: BooleanType {
     public func not() -> Signal<Bool, E> {
         return Signal { observer in
             return self.observe { (event: Event<T, E>) in
-                observer(event.map { value in !value })
+                observer(event.map { !$0 })
             }
         }
     }

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -99,3 +99,14 @@ extension SignalProducerType where T: SequenceType {
     }
 }
 
+
+// MARK: Boolean Operations
+
+extension SignalProducerType where T: BooleanType {
+    /// Returns a producer that inverts every value sent on self
+    @warn_unused_result(message="Did you forget to call `start` on the producer?")
+    public func not() -> SignalProducer<Bool, E> {
+        return lift { $0.not() }
+    }
+}
+

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -110,3 +110,31 @@ extension SignalProducerType where T: BooleanType {
     }
 }
 
+extension SignalProducerType where T: SequenceType, T.Generator.Element: BooleanType {
+    /// Returns a producer that sends `a && b && c && ...` for each value (a, b, c, ...) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func and() -> SignalProducer<Bool, E> {
+        return lift { $0.and() }
+    }
+    
+    /// Returns a producer that sends `a ||& b || c || ...` for each value (a, b, c, ...) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func or() -> SignalProducer<Bool, E> {
+        return lift { $0.or() }
+    }
+}
+
+extension SignalProducerType where T == (Bool, Bool) {
+    /// Returns a producer that sends `a && b` for each value (a, b) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func and() -> SignalProducer<Bool, E> {
+        return lift { $0.and() }
+    }
+    
+    /// Returns a producer that sends `a || b` for each value (a, b) sent on self
+    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
+    public func or() -> SignalProducer<Bool, E> {
+        return lift { $0.or() }
+    }
+}
+

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -134,6 +134,23 @@ final class SignalTests: XCTestCase {
         sendNext(sink, [2, 3])
         XCTAssert(values == [1, 2, 3])
     }
+    
+    func testNot() {
+        let (signal, sink) = Signal<Bool, NoError>.pipe()
+        var invertedValue = false
+        
+        signal
+            .not()
+            .observe(next: {
+                invertedValue = $0
+            })
+        
+        sendNext(sink, false)
+        XCTAssertTrue(invertedValue)
+
+        sendNext(sink, true)
+        XCTAssertFalse(invertedValue)
+    }
 }
 
 enum TestError: ErrorType {

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -151,6 +151,98 @@ final class SignalTests: XCTestCase {
         sendNext(sink, true)
         XCTAssertFalse(invertedValue)
     }
+    
+    func testAndSequenceType() {
+        let (signal, sink) = Signal<[Bool], NoError>.pipe()
+        var result = false
+        
+        signal
+            .and()
+            .observe(next: {
+                result = $0
+            })
+        
+        sendNext(sink, [true, true])
+        XCTAssertTrue(result)
+        
+        sendNext(sink, [true, false])
+        XCTAssertFalse(result)
+        
+        sendNext(sink, [false, true])
+        XCTAssertFalse(result)
+        
+        sendNext(sink, [false, false])
+        XCTAssertFalse(result)
+    }
+    
+    func testOrSequenceType() {
+        let (signal, sink) = Signal<[Bool], NoError>.pipe()
+        var result = false
+        
+        signal
+            .or()
+            .observe(next: {
+                result = $0
+            })
+        
+        sendNext(sink, [true, true])
+        XCTAssertTrue(result)
+        
+        sendNext(sink, [true, false])
+        XCTAssertTrue(result)
+        
+        sendNext(sink, [false, true])
+        XCTAssertTrue(result)
+        
+        sendNext(sink, [false, false])
+        XCTAssertFalse(result)
+    }
+    
+    func testAndTuple2() {
+        let (signal, sink) = Signal<(Bool, Bool), NoError>.pipe()
+        var result = false
+        
+        signal
+            .and()
+            .observe(next: {
+                result = $0
+            })
+        
+        sendNext(sink, (true, true))
+        XCTAssertTrue(result)
+        
+        sendNext(sink, (true, false))
+        XCTAssertFalse(result)
+        
+        sendNext(sink, (false, true))
+        XCTAssertFalse(result)
+        
+        sendNext(sink, (false, false))
+        XCTAssertFalse(result)
+    }
+    
+    func testOrTuple2() {
+        let (signal, sink) = Signal<(Bool, Bool), NoError>.pipe()
+        var result = false
+        
+        signal
+            .or()
+            .observe(next: {
+                result = $0
+            })
+        
+        sendNext(sink, (true, true))
+        XCTAssertTrue(result)
+        
+        sendNext(sink, (true, false))
+        XCTAssertTrue(result)
+        
+        sendNext(sink, (false, true))
+        XCTAssertTrue(result)
+        
+        sendNext(sink, (false, false))
+        XCTAssertFalse(result)
+    }
 }
 
 enum TestError: ErrorType {


### PR DESCRIPTION
I needed to port these operations from RAC 2.x to RAC 4 in a project I'm currently working and thought it might be nice to have them "back" in the framework. I'm not sure right now how's the current state in Reactive Cocoa in regards to adding new features ( https://github.com/ReactiveCocoa/ReactiveCocoa/issues/2075#issuecomment-109792304 - still valid vor 4.0 I guess?) thats why I've opened this PR here.

If you think thats cool, I would also add all the necessary overloads for `and` and `or` for 
- `extension SignalType where T == (Bool, Bool, Bool)`
- `extension SignalType where T == (Bool, Bool, Bool, Bool)`
- ...

up to tuples of 10 `Bool`s to match up the `combineLatest` overloads in RAC.
