### PR TITLE
Replace `start` and `observe` overloads with new Observer API

### DIFF
--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -58,7 +58,7 @@ public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticStr
 public func associatedProperty<T>(host: AnyObject, key: UnsafePointer<()>, initial: () -> T, setter: T -> ()) -> MutableProperty<T> {
     return associatedObject(host, key: key) {
         let property = MutableProperty(initial())
-        property.producer.start(next: setter)
+        property.producer.start(Observer(next: setter))
         return property
     }
 }

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -61,7 +61,7 @@ extension NSObject {
     public func rex_valueProperty<T>(key: UnsafePointer<()>, _ initial: () -> T, _ setter: T -> ()) -> MutableProperty<T> {
         return associatedObject(self, key: key) {
             let property = MutableProperty(initial())
-            property.producer.start(next: setter)
+            property.producer.start(Observer(next: setter))
             return property
         }
     }

--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -10,29 +10,11 @@ import ReactiveCocoa
 
 extension SignalType {
 
-    /// Bring back the `observe` overload. The `observeNext` or pattern matching
-    /// on `observe(Event)` is still annoying in practice and more verbose. This is
-    /// also likely to change in a later RAC 4 alpha.
-    internal func observe(next next: (Value -> ())? = nil, error: (Error -> ())? = nil, completed: (() -> ())? = nil, interrupted: (() -> ())? = nil) -> Disposable? {
-        return self.observe { (event: Event<Value, Error>) in
-            switch event {
-            case let .Next(value):
-                next?(value)
-            case let .Error(err):
-                error?(err)
-            case .Completed:
-                completed?()
-            case .Interrupted:
-                interrupted?()
-            }
-        }
-    }
-
     /// Applies `transform` to values from `signal` with non-`nil` results unwrapped and
     /// forwared on the returned signal.
     public func filterMap<U>(transform: Value -> U?) -> Signal<U, Error> {
         return Signal<U, Error> { observer in
-            return self.observe(next: { value in
+            return self.observe(Observer(next: { value in
                 if let val = transform(value) {
                     observer.sendNext(val)
                 }
@@ -42,7 +24,7 @@ extension SignalType {
                 observer.sendCompleted()
             }, interrupted: {
                 observer.sendInterrupted()
-            })
+            }))
         }
     }
 

--- a/Source/UIKit/UIBarButtonItem.swift
+++ b/Source/UIKit/UIBarButtonItem.swift
@@ -19,10 +19,10 @@ extension UIBarButtonItem {
             let initial = CocoaAction.rex_disabled
             let property = MutableProperty(initial)
             
-            property.producer.start(next: { next in
+            property.producer.start(Observer(next: { next in
                 self?.target = next
                 self?.action = CocoaAction.selector
-            })
+            }))
 
             if let strongSelf = self {
                 strongSelf.rex_enabled <~ property.producer.flatMap(.Latest) { $0.rex_enabledProducer }

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -21,10 +21,10 @@ extension UIButton {
 
             property.producer
                 .combinePrevious(initial)
-                .start(next: { previous, next in
+                .start(Observer(next: { previous, next in
                     self?.removeTarget(previous, action: CocoaAction.selector, forControlEvents: .TouchUpInside)
                     self?.addTarget(next, action: CocoaAction.selector, forControlEvents: .TouchUpInside)
-                })
+                }))
 
             if let strongSelf = self {
                 strongSelf.rex_enabled <~ property.producer.flatMap(.Latest) { $0.rex_enabledProducer }

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
-@testable import Rex
+import Rex
 import ReactiveCocoa
 import XCTest
 
@@ -16,7 +16,7 @@ final class NSObjectTests: XCTestCase {
         let object = Object()
         var value: String = ""
 
-        object.rex_producerForKeyPath("string").start(next: { value = $0 })
+        object.rex_producerForKeyPath("string").start(Observer(next: { value = $0 }))
         XCTAssertEqual(value, "foo")
 
         object.string = "bar"

--- a/Tests/SignalProducerTests.swift
+++ b/Tests/SignalProducerTests.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
-@testable import Rex
+import Rex
 import ReactiveCocoa
 import XCTest
 
@@ -22,17 +22,17 @@ final class SignalProducerTests: XCTestCase {
 
         disposable += producer
             .groupBy { $0 % 2 == 0 }
-            .start(next: { key, group in
+            .start(Observer(next: { key, group in
                 if key {
-                    group.start(next: { evens.append($0) })
+                    group.start(Observer(next: { evens.append($0) }))
                 } else {
-                    group.start(next: { odds.append($0) })
+                    group.start(Observer(next: { odds.append($0) }))
                 }
             },completed: {
                 completed = true
             }, interrupted: {
                 interrupted = true
-            })
+            }))
 
         sink.sendNext(1)
         XCTAssert(evens == [])

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
-@testable import Rex
+import Rex
 import ReactiveCocoa
 import XCTest
 
@@ -20,7 +20,7 @@ final class SignalTests: XCTestCase {
             .filterMap {
                 return $0 % 2 == 0 ? String($0) : nil
             }
-            .observe(next: { values.append($0) })
+            .observe(Observer(next: { values.append($0) }))
 
         sink.sendNext(1)
         XCTAssert(values == [])
@@ -41,9 +41,9 @@ final class SignalTests: XCTestCase {
 
         signal
             .ignoreError()
-            .observe(completed: {
+            .observe(Observer(completed: {
                 completed = true
-            })
+            }))
 
         sink.sendNext(1)
         XCTAssertFalse(completed)
@@ -58,9 +58,9 @@ final class SignalTests: XCTestCase {
 
         signal
             .ignoreError(replacement: .Interrupted)
-            .observe(interrupted: {
+            .observe(Observer(interrupted: {
                 interrupted = true
-            })
+            }))
 
         sink.sendNext(1)
         XCTAssertFalse(interrupted)
@@ -77,10 +77,10 @@ final class SignalTests: XCTestCase {
 
         signal
             .timeoutAfter(2, withEvent: .Interrupted, onScheduler: scheduler)
-            .observe(
+            .observe(Observer(
                 completed: { completed = true },
                 interrupted: { interrupted = true }
-            )
+            ))
 
         scheduler.scheduleAfter(1) { sink.sendCompleted() }
 
@@ -100,10 +100,10 @@ final class SignalTests: XCTestCase {
 
         signal
             .timeoutAfter(2, withEvent: .Interrupted, onScheduler: scheduler)
-            .observe(
+            .observe(Observer(
                 completed: { completed = true },
                 interrupted: { interrupted = true }
-            )
+            ))
 
         scheduler.scheduleAfter(3) { sink.sendCompleted() }
 
@@ -121,9 +121,9 @@ final class SignalTests: XCTestCase {
 
         signal
             .uncollect()
-            .observe(next: {
+            .observe(Observer(next: {
                 values.append($0)
-            })
+            }))
 
         sink.sendNext([])
         XCTAssert(values.isEmpty)


### PR DESCRIPTION
How do you feel about it?
