### PR TITLE
Fix test fails

### DIFF
--- a/Tests/UIKit/UIButtonTests.swift
+++ b/Tests/UIKit/UIButtonTests.swift
@@ -17,7 +17,7 @@ extension UIButton {
     }
     
     override public func sendAction(action: Selector, to target: AnyObject?, forEvent event: UIEvent?) {
-        target?.performSelector(action)
+        target?.performSelector(action, withObject: nil)
     }
 }
 
@@ -87,9 +87,10 @@ class UIButtonTests: XCTestCase {
         }
         
         passed <~ SignalProducer(signal: action.values)
-        button.rex_pressed.value = CocoaAction(action, input: ())
+        button.rex_pressed <~ SignalProducer(value: CocoaAction(action, input: ()))
         
         button.sendActionsForControlEvents(.TouchUpInside)
+        
         
         XCTAssertTrue(passed.value)
     }

--- a/Tests/UIKit/UIViewTests.swift
+++ b/Tests/UIKit/UIViewTests.swift
@@ -24,7 +24,7 @@ class UIViewTests: XCTestCase {
         _view = view
         
         view.rex_alpha <~ SignalProducer(value: 0.5)
-        XCTAssert(_view?.alpha == 0.5)
+        XCTAssertEqualWithAccuracy(_view!.alpha, 0.5, accuracy: 0.01)
     }
     
     func testHiddenPropertyDoesntCreateRetainCycle() {
@@ -59,8 +59,8 @@ class UIViewTests: XCTestCase {
         view.rex_alpha <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(firstChange)
-        XCTAssertEqual(view.alpha, firstChange)
+        XCTAssertEqualWithAccuracy(view.alpha, firstChange, accuracy: 0.01)
         observer.sendNext(secondChange)
-        XCTAssertEqual(view.alpha, secondChange)
+        XCTAssertEqualWithAccuracy(view.alpha, secondChange, accuracy: 0.01)
     }
 }


### PR DESCRIPTION
I had some problems with the tests introduced in #59
- `UIButtonTests:testPressedProperty` caused a crash because `performSelector` was used without an object, but the `"execute:"` selector expected an object.
- `UIViewTests:testAlphaProperty` failed for me at the last assertion because it was asserted that the alpha is exactly equal to the original value 0.7, but when running, I was getting `view.alpha = 0.699999999something`
