### PR TITLE
Add testcase that replicates a bug with binding UIControl.enabled and UIControl.selected

### DIFF
--- a/Tests/UIKit/UIControlTests.swift
+++ b/Tests/UIKit/UIControlTests.swift
@@ -81,4 +81,26 @@ class UIControlTests: XCTestCase {
         observer.sendNext(false)
         XCTAssertFalse(control.highlighted)
     }
+    
+    func testEnabledAndSelectedProperty() {
+        let control = UIControl(frame: CGRectZero)
+        control.selected = false
+        control.enabled = false
+        
+        let (pipeSignalSelected, observerSelected) = Signal<Bool, NoError>.pipe()
+        let (pipeSignalEnabled, observerEnabled) = Signal<Bool, NoError>.pipe()
+        control.rex_selected <~ SignalProducer(signal: pipeSignalSelected)
+        control.rex_enabled <~ SignalProducer(signal: pipeSignalEnabled)
+        
+        observerSelected.sendNext(true)
+        observerEnabled.sendNext(true)
+        XCTAssertTrue(control.enabled)
+        XCTAssertTrue(control.selected)
+        observerSelected.sendNext(false)
+        XCTAssertTrue(control.enabled)
+        XCTAssertFalse(control.selected)
+        observerEnabled.sendNext(false)
+        XCTAssertFalse(control.enabled)
+        XCTAssertFalse(control.selected)
+    }
 }


### PR DESCRIPTION
I came across this issue today and I was able to reproduce the issue in a test case:

Binding to `rex_enabled` of a `UIControl` does not seem to work anymore, as soon as `rex_selected` is also used. 

When I run this testcase, the asserts in line 97 and 100 fail unexpectedly.
When I disable line 92, those asserts hold and only the assert in line 98 fails (as expected).

Using 

```
pipeSignalEnabled.observeNext {
    control.enabled = $0
}
```

instead of 

```
control.rex_enabled <~ SignalProducer(signal: pipeSignalEnabled)
```

works as expected.

I had a quick look at the implementation of those, but I dont see any obvious errors - not sure if I can help with the actual error…
