### PR TITLE
[POC] Reconsider associatedProperty(), associatedObject(), rex_valueProperty() interfaces

### DIFF
--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -52,9 +52,6 @@ public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticStr
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-///
-/// N.B. Ensure that `host` isn't strongly captured by `initial` or `setter`, otherwise this
-/// will create a retain cycle with `host` causing it to never dealloc.
 public func associatedProperty<Host: AnyObject, T>(host: Host, key: UnsafePointer<()>, initial: Host -> T, setter: (Host, T) -> ()) -> MutableProperty<T> {
     return associatedObject(host, key: key) { host in
         let property = MutableProperty(initial(host))
@@ -72,9 +69,6 @@ public func associatedProperty<Host: AnyObject, T>(host: Host, key: UnsafePointe
 /// On first use attaches the object returned from `initial` to the `host` object using
 /// `key` via `objc_setAssociatedObject`. On subsequent usage, returns said object via
 /// `objc_getAssociatedObject`.
-///
-/// N.B. Ensure that `host` isn't strongly captured by `initial`, otherwise this will
-/// create a retain cycle with `host` causing it to never dealloc.
 public func associatedObject<Host: AnyObject, T: AnyObject>(host: Host, key: UnsafePointer<()>, initial: Host -> T) -> T {
     var value = objc_getAssociatedObject(host, key) as? T
     if value == nil {

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -9,12 +9,6 @@
 import Foundation
 import ReactiveCocoa
 
-public protocol NSObjectType {
-    typealias InstanceType = Self
-}
-
-extension NSObject: NSObjectType {}
-
 extension NSObject {
     /// Creates a strongly-typed producer to monitor `keyPath` via KVO. The caller
     /// is responsible for ensuring that the associated value is castable to `T`.
@@ -53,20 +47,5 @@ extension NSObject {
     /// create a retain cycle causing `self` to never dealloc.
     public func rex_classProperty<T: AnyObject>(keyPath: StaticString, placeholder: () -> T) -> MutableProperty<T> {
         return associatedProperty(self, keyPath: keyPath, placeholder: placeholder)
-    }
-}
-
-extension NSObjectType where Self: NSObject, InstanceType == Self {
-    /// Attaches a `MutableProperty` value under `key`. The property is initialized with
-    /// the result of `initial`. Changes on the property's producer are monitored and
-    /// written to `setter`.
-    ///
-    /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
-    /// bindings on Cocoa objects.
-    ///
-    /// N.B. Ensure that `self` isn't strongly captured by `initial` or `setter`, otherwise this
-    /// will create a retain cycle causing `self` to never dealloc.
-    public func rex_valueProperty<T>(key: UnsafePointer<()>, _ initial: InstanceType -> T, _ setter: (InstanceType, T) -> ()) -> MutableProperty<T> {
-        return associatedProperty(self, key: key, initial: initial, setter: setter)
     }
 }

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -9,6 +9,12 @@
 import Foundation
 import ReactiveCocoa
 
+public protocol NSObjectType {
+    typealias InstanceType = Self
+}
+
+extension NSObject: NSObjectType {}
+
 extension NSObject {
     /// Creates a strongly-typed producer to monitor `keyPath` via KVO. The caller
     /// is responsible for ensuring that the associated value is castable to `T`.
@@ -48,7 +54,9 @@ extension NSObject {
     public func rex_classProperty<T: AnyObject>(keyPath: StaticString, placeholder: () -> T) -> MutableProperty<T> {
         return associatedProperty(self, keyPath: keyPath, placeholder: placeholder)
     }
+}
 
+extension NSObjectType where Self: NSObject, InstanceType == Self {
     /// Attaches a `MutableProperty` value under `key`. The property is initialized with
     /// the result of `initial`. Changes on the property's producer are monitored and
     /// written to `setter`.
@@ -58,7 +66,7 @@ extension NSObject {
     ///
     /// N.B. Ensure that `self` isn't strongly captured by `initial` or `setter`, otherwise this
     /// will create a retain cycle causing `self` to never dealloc.
-    public func rex_valueProperty<T>(key: UnsafePointer<()>, _ initial: () -> T, _ setter: T -> ()) -> MutableProperty<T> {
+    public func rex_valueProperty<T>(key: UnsafePointer<()>, _ initial: InstanceType -> T, _ setter: (InstanceType, T) -> ()) -> MutableProperty<T> {
         return associatedProperty(self, key: key, initial: initial, setter: setter)
     }
 }

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -25,14 +25,4 @@ extension NSObject {
                 return .empty
             }
     }
-
-    /// Attaches a `MutableProperty` relying on KVC for the initial value and subsequent
-    /// updates. Note that `keyPath` is a `StaticString` because it's pointer value is used
-    /// as key value when associating the property.
-    ///
-    /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
-    /// bindings on Cocoa objects.
-    public func rex_stringProperty(keyPath: StaticString) -> MutableProperty<String> {
-        return associatedProperty(self, keyPath: keyPath)
-    }
 }

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -35,17 +35,4 @@ extension NSObject {
     public func rex_stringProperty(keyPath: StaticString) -> MutableProperty<String> {
         return associatedProperty(self, keyPath: keyPath)
     }
-
-    /// Attaches a `MutableProperty` relying on KVC for the initial value and subsequent
-    /// updates. Note that `keyPath` is a `StaticString` because it's pointer value is used
-    /// as key value when associating the property.
-    ///
-    /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
-    /// bindings on Cocoa objects.
-    ///
-    /// N.B. Ensure that `self` isn't strongly captured by `placeholder`, otherwise this will
-    /// create a retain cycle causing `self` to never dealloc.
-    public func rex_classProperty<T: AnyObject>(keyPath: StaticString, placeholder: () -> T) -> MutableProperty<T> {
-        return associatedProperty(self, keyPath: keyPath, placeholder: placeholder)
-    }
 }

--- a/Source/UIKit/UIBarItem.swift
+++ b/Source/UIKit/UIBarItem.swift
@@ -12,7 +12,7 @@ import UIKit
 extension UIBarItem {
     /// Wraps a UIBarItem's `enabled` state in a bindable property.
     public var rex_enabled: MutableProperty<Bool> {
-        return associatedProperty(self, key: &enabledKey, initial: { [weak self] in self?.enabled ?? true }, setter: { [weak self] in self?.enabled = $0 })
+        return associatedProperty(self, key: &enabledKey, initial: { $0.enabled }, setter: { $0.enabled = $1 })
     }
 }
 

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -10,8 +10,6 @@ import ReactiveCocoa
 import UIKit
 
 extension UIButton {
-    public typealias InstanceType = UIButton
-
     /// Exposes a property that binds an action to button presses. The action is set as
     /// a target of the button for `TouchUpInside` events. When property changes occur the
     /// previous action is removed as a target. This also binds the enabled state of the
@@ -38,7 +36,7 @@ extension UIButton {
     /// Wraps a button's `title` text in a bindable property. Note that this only applies
     /// to `UIControlState.Normal`.
     public var rex_title: MutableProperty<String> {
-        return rex_valueProperty(&titleKey, { $0.titleForState(.Normal) ?? "" }, { $0.setTitle($1, forState: .Normal) })
+        return associatedProperty(self, key: &titleKey, initial: { $0.titleForState(.Normal) ?? "" }, setter: { $0.setTitle($1, forState: .Normal) })
     }
 }
 

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -10,6 +10,8 @@ import ReactiveCocoa
 import UIKit
 
 extension UIButton {
+    public typealias InstanceType = UIButton
+
     /// Exposes a property that binds an action to button presses. The action is set as
     /// a target of the button for `TouchUpInside` events. When property changes occur the
     /// previous action is removed as a target. This also binds the enabled state of the
@@ -36,7 +38,7 @@ extension UIButton {
     /// Wraps a button's `title` text in a bindable property. Note that this only applies
     /// to `UIControlState.Normal`.
     public var rex_title: MutableProperty<String> {
-        return rex_valueProperty(&titleKey, { [weak self] in self?.titleForState(.Normal) ?? "" }, { [weak self] in self?.setTitle($0, forState: .Normal) })
+        return rex_valueProperty(&titleKey, { $0.titleForState(.Normal) ?? "" }, { $0.setTitle($1, forState: .Normal) })
     }
 }
 

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -10,6 +10,8 @@ import ReactiveCocoa
 import UIKit
 
 extension UIControl {
+    public typealias InstanceType = UIControl
+
     /// Creates a producer for the sender whenever a specified control event is triggered.
     public func rex_controlEvents(events: UIControlEvents) -> SignalProducer<UIControl?, NoError> {
         return rac_signalForControlEvents(events)
@@ -20,17 +22,17 @@ extension UIControl {
 
     /// Wraps a control's `enabled` state in a bindable property.
     public var rex_enabled: MutableProperty<Bool> {
-        return rex_valueProperty(&enabledKey, { [weak self] in self?.enabled ?? true }, { [weak self] in self?.enabled = $0 })
+        return rex_valueProperty(&enabledKey, { $0.enabled }, { $0.enabled = $1 })
     }
     
     /// Wraps a control's `selected` state in a bindable property.
     public var rex_selected: MutableProperty<Bool> {
-        return rex_valueProperty(&selectedKey, { [weak self] in self?.selected ?? false }, { [weak self] in self?.selected = $0 })
+        return rex_valueProperty(&selectedKey, { $0.selected }, { $0.selected = $1 })
     }
     
     /// Wraps a control's `highlighted` state in a bindable property.
     public var rex_highlighted: MutableProperty<Bool> {
-        return rex_valueProperty(&highlightedKey, { [weak self] in self?.highlighted ?? false }, { [weak self] in self?.highlighted = $0 })
+        return rex_valueProperty(&highlightedKey, { $0.highlighted }, { $0.highlighted = $1 })
     }
 }
 

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -10,8 +10,6 @@ import ReactiveCocoa
 import UIKit
 
 extension UIControl {
-    public typealias InstanceType = UIControl
-
     /// Creates a producer for the sender whenever a specified control event is triggered.
     public func rex_controlEvents(events: UIControlEvents) -> SignalProducer<UIControl?, NoError> {
         return rac_signalForControlEvents(events)
@@ -22,17 +20,17 @@ extension UIControl {
 
     /// Wraps a control's `enabled` state in a bindable property.
     public var rex_enabled: MutableProperty<Bool> {
-        return rex_valueProperty(&enabledKey, { $0.enabled }, { $0.enabled = $1 })
+        return associatedProperty(self, key: &enabledKey, initial: { $0.enabled }, setter: { $0.enabled = $1 })
     }
     
     /// Wraps a control's `selected` state in a bindable property.
     public var rex_selected: MutableProperty<Bool> {
-        return rex_valueProperty(&selectedKey, { $0.selected }, { $0.selected = $1 })
+        return associatedProperty(self, key: &selectedKey, initial: { $0.selected }, setter: { $0.selected = $1 })
     }
     
     /// Wraps a control's `highlighted` state in a bindable property.
     public var rex_highlighted: MutableProperty<Bool> {
-        return rex_valueProperty(&highlightedKey, { $0.highlighted }, { $0.highlighted = $1 })
+        return associatedProperty(self, key: &highlightedKey, initial: { $0.highlighted }, setter: { $0.highlighted = $1 })
     }
 }
 

--- a/Source/UIKit/UIImageView.swift
+++ b/Source/UIKit/UIImageView.swift
@@ -10,14 +10,16 @@ import ReactiveCocoa
 import UIKit
 
 extension UIImageView {
+    public typealias InstanceType = UIImageView
+
     /// Wraps a imageView's `image` value in a bindable property.
     public var rex_image: MutableProperty<UIImage?> {
-        return rex_valueProperty(&imageKey, { [weak self] in self?.image }, { [weak self] in self?.image = $0 })
+        return rex_valueProperty(&imageKey, { $0.image }, { $0.image = $1 })
     }
     
     /// Wraps a imageView's `highlightedImage` value in a bindable property.
     public var rex_highlightedImage: MutableProperty<UIImage?> {
-        return rex_valueProperty(&highlightedImageKey, { [weak self] in self?.highlightedImage }, { [weak self] in self?.highlightedImage = $0 })
+        return rex_valueProperty(&highlightedImageKey, { $0.highlightedImage }, { $0.highlightedImage = $1 })
     }
 }
 

--- a/Source/UIKit/UIImageView.swift
+++ b/Source/UIKit/UIImageView.swift
@@ -10,16 +10,14 @@ import ReactiveCocoa
 import UIKit
 
 extension UIImageView {
-    public typealias InstanceType = UIImageView
-
     /// Wraps a imageView's `image` value in a bindable property.
     public var rex_image: MutableProperty<UIImage?> {
-        return rex_valueProperty(&imageKey, { $0.image }, { $0.image = $1 })
+        return associatedProperty(self, key: &imageKey, initial: { $0.image }, setter: { $0.image = $1 })
     }
     
     /// Wraps a imageView's `highlightedImage` value in a bindable property.
     public var rex_highlightedImage: MutableProperty<UIImage?> {
-        return rex_valueProperty(&highlightedImageKey, { $0.highlightedImage }, { $0.highlightedImage = $1 })
+        return associatedProperty(self, key: &highlightedImageKey, initial: { $0.highlightedImage }, setter: { $0.highlightedImage = $1 })
     }
 }
 

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -10,14 +10,12 @@ import ReactiveCocoa
 import UIKit
 
 extension UILabel {
-    public typealias InstanceType = UILabel
-
     /// Wraps a label's `text` value in a bindable property.
     public var rex_text: MutableProperty<String> {
         return rex_stringProperty("text")
     }
     
     public var rex_textColor: MutableProperty<UIColor> {
-        return rex_valueProperty(&textColor, { $0.textColor }, { $0.textColor = $1 })
+        return associatedProperty(self, key: &textColor, initial: { $0.textColor }, setter: { $0.textColor = $1 })
     }
 }

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -10,12 +10,14 @@ import ReactiveCocoa
 import UIKit
 
 extension UILabel {
+    public typealias InstanceType = UILabel
+
     /// Wraps a label's `text` value in a bindable property.
     public var rex_text: MutableProperty<String> {
         return rex_stringProperty("text")
     }
     
     public var rex_textColor: MutableProperty<UIColor> {
-        return rex_valueProperty(&textColor, { [weak self] in self?.textColor ?? UILabel().textColor }, { [weak self] in self?.textColor = $0 })
+        return rex_valueProperty(&textColor, { $0.textColor }, { $0.textColor = $1 })
     }
 }

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -12,7 +12,7 @@ import UIKit
 extension UILabel {
     /// Wraps a label's `text` value in a bindable property.
     public var rex_text: MutableProperty<String> {
-        return rex_stringProperty("text")
+        return associatedProperty(self, keyPath: "text")
     }
     
     public var rex_textColor: MutableProperty<UIColor> {

--- a/Source/UIKit/UIView.swift
+++ b/Source/UIKit/UIView.swift
@@ -10,14 +10,16 @@ import ReactiveCocoa
 import UIKit
 
 extension UIView {
+    public typealias InstanceType = UIView
+
     /// Wraps a view's `alpha` value in a bindable property.
     public var rex_alpha: MutableProperty<CGFloat> {
-        return rex_valueProperty(&alphaKey, { [weak self] in self?.alpha ?? 1.0 }, { [weak self] in self?.alpha = $0 })
+        return rex_valueProperty(&alphaKey, { $0.alpha }, { $0.alpha = $1 })
     }
     
     /// Wraps a view's `hidden` state in a bindable property.
     public var rex_hidden: MutableProperty<Bool> {
-        return rex_valueProperty(&hiddenKey, { [weak self] in self?.hidden ?? false }, { [weak self] in self?.hidden = $0 })
+        return rex_valueProperty(&hiddenKey, { $0.hidden }, { $0.hidden = $1 })
     }
 }
 

--- a/Source/UIKit/UIView.swift
+++ b/Source/UIKit/UIView.swift
@@ -10,16 +10,14 @@ import ReactiveCocoa
 import UIKit
 
 extension UIView {
-    public typealias InstanceType = UIView
-
     /// Wraps a view's `alpha` value in a bindable property.
     public var rex_alpha: MutableProperty<CGFloat> {
-        return rex_valueProperty(&alphaKey, { $0.alpha }, { $0.alpha = $1 })
+        return associatedProperty(self, key: &alphaKey, initial: { $0.alpha }, setter: { $0.alpha = $1 })
     }
     
     /// Wraps a view's `hidden` state in a bindable property.
     public var rex_hidden: MutableProperty<Bool> {
-        return rex_valueProperty(&hiddenKey, { $0.hidden }, { $0.hidden = $1 })
+        return associatedProperty(self, key: &hiddenKey, initial: { $0.hidden }, setter: { $0.hidden = $1 })
     }
 }
 

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -37,7 +37,7 @@ final class NSObjectDeallocTests: XCTestCase {
         let object = Object()
         _object = object
 
-        object.rex_stringProperty("string") <~ SignalProducer(value: "Test")
+        associatedProperty(object, keyPath: "string") <~ SignalProducer(value: "Test")
         XCTAssert(_object?.string == "Test")
     }
 

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -45,7 +45,7 @@ final class NSObjectDeallocTests: XCTestCase {
         let object = Object()
         _object = object
 
-        object.rex_classProperty("string", placeholder: { _ in "" }) <~ SignalProducer(value: "Test")
+        associatedProperty(object, keyPath: "string", placeholder: { _ in "" }) <~ SignalProducer(value: "Test")
         XCTAssert(_object?.string == "Test")
     }
 }


### PR DESCRIPTION
This change enables to pass the host (receiver) instance to `initial` and `setter` closures. Thus the caller of the functions don't need to use weak-captured host instance to implement the closures.

`NSObjectType` protocol and `rex_valueProperty()` which is based on its `InstanceType` typealias might seem tricky. We can remove the trick if needed with the way as `UIBarItem.rex_enabled` is implemented (direct use of `associatedProperty()`).
