### PR TITLE
ReactiveCocoa 4.0 support

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "1.0.1"
-github "ReactiveCocoa/ReactiveCocoa" "v4.0.0"
+github "antitypical/Result" "1.0.2"
+github "ReactiveCocoa/ReactiveCocoa" "v4.0.1"

--- a/Rex.podspec
+++ b/Rex.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'Rex'
   s.module_name  = 'Rex'
-  s.version      = '0.9.0-RC.2'
+  s.version      = '0.9.0'
   s.summary      = 'ReactiveCocoa Extensions'
 
   s.description  = <<-DESC
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => '0.9.0-RC.2' }
-  s.dependency 'ReactiveCocoa', '4.0.0-RC.2'
+  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => '0.9.0' }
+  s.dependency 'ReactiveCocoa', '~> 4.0'
   s.ios.framework  = 'UIKit'
   s.osx.framework  = 'AppKit'
 

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -7,6 +7,7 @@
 //
 
 import ReactiveCocoa
+import enum Result.NoError
 
 extension Action {
     /// Creates an always disabled action.

--- a/Source/AppKit/NSTextField.swift
+++ b/Source/AppKit/NSTextField.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ReactiveCocoa
 import AppKit
+import enum Result.NoError
 
 extension NSTextField {
     /// Sends the field's string value whenever it changes.

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import enum Result.NoError
 
 extension NSObject {
     /// Creates a strongly-typed producer to monitor `keyPath` via KVO. The caller

--- a/Source/Foundation/NSUserDefaults.swift
+++ b/Source/Foundation/NSUserDefaults.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactiveCocoa
+import enum Result.NoError
 
 extension NSUserDefaults {
     /// Sends value of `key` whenever it changes. Attempts to filter out repeats

--- a/Source/Property.swift
+++ b/Source/Property.swift
@@ -7,6 +7,7 @@
 //
 
 import ReactiveCocoa
+import enum Result.NoError
 
 extension PropertyType where Value == Bool {
     /// The conjunction of `self` and `other`.

--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -7,6 +7,7 @@
 //
 
 import ReactiveCocoa
+import enum Result.NoError
 
 extension SignalType {
 

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -7,6 +7,7 @@
 //
 
 import ReactiveCocoa
+import enum Result.NoError
 
 extension SignalProducerType {
 

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -8,6 +8,7 @@
 
 import ReactiveCocoa
 import UIKit
+import enum Result.NoError
 
 extension UIControl {
 #if os(iOS)

--- a/Source/UIKit/UITextField.swift
+++ b/Source/UIKit/UITextField.swift
@@ -9,6 +9,7 @@
 import Foundation
 import ReactiveCocoa
 import UIKit
+import enum Result.NoError
 
 extension UITextField {
     

--- a/Tests/PropertyTests.swift
+++ b/Tests/PropertyTests.swift
@@ -9,6 +9,7 @@
 @testable import Rex
 import ReactiveCocoa
 import XCTest
+import enum Result.NoError
 
 final class PropertyTests: XCTestCase {
 

--- a/Tests/SignalProducerTests.swift
+++ b/Tests/SignalProducerTests.swift
@@ -9,6 +9,7 @@
 import Rex
 import ReactiveCocoa
 import XCTest
+import enum Result.NoError
 
 final class SignalProducerTests: XCTestCase {
 

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -9,6 +9,7 @@
 import Rex
 import ReactiveCocoa
 import XCTest
+import enum Result.NoError
 
 final class SignalTests: XCTestCase {
 

--- a/Tests/UIKit/UIBarButtonItemTests.swift
+++ b/Tests/UIKit/UIBarButtonItemTests.swift
@@ -9,6 +9,7 @@
 import ReactiveCocoa
 import UIKit
 import XCTest
+import enum Result.NoError
 
 class UIBarButtonItemTests: XCTestCase {
 

--- a/Tests/UIKit/UIButtonTests.swift
+++ b/Tests/UIKit/UIButtonTests.swift
@@ -9,6 +9,7 @@
 import ReactiveCocoa
 import UIKit
 import XCTest
+import enum Result.NoError
 
 extension UIButton {
     static func button() -> UIButton {

--- a/Tests/UIKit/UIControlTests.swift
+++ b/Tests/UIKit/UIControlTests.swift
@@ -9,6 +9,7 @@
 import ReactiveCocoa
 import UIKit
 import XCTest
+import enum Result.NoError
 
 class UIControlTests: XCTestCase {
     

--- a/Tests/UIKit/UIImageViewTests.swift
+++ b/Tests/UIKit/UIImageViewTests.swift
@@ -9,6 +9,7 @@
 import ReactiveCocoa
 import UIKit
 import XCTest
+import enum Result.NoError
 
 class UIImageViewTests: XCTestCase {
     

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -9,6 +9,7 @@
 import ReactiveCocoa
 import UIKit
 import XCTest
+import enum Result.NoError
 
 class UILabelTests: XCTestCase {
 

--- a/Tests/UIKit/UIViewTests.swift
+++ b/Tests/UIKit/UIViewTests.swift
@@ -9,6 +9,7 @@
 import ReactiveCocoa
 import UIKit
 import XCTest
+import enum Result.NoError
 
 class UIViewTests: XCTestCase {
     


### PR DESCRIPTION
Fixes a minor issues with the final ReactiveCocoa 4.0 release, which uses `Result.NoError` instead of its own `NoError` type. I also updated the Podspec and changed the version to 0.9.0.
