### PR TITLE
We require 4.0.1 of RAC to work

### DIFF
--- a/Rex.podspec
+++ b/Rex.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => '0.9.0' }
-  s.dependency 'ReactiveCocoa', '~> 4.0'
+  s.dependency 'ReactiveCocoa', '~> 4.0.1'
   s.ios.framework  = 'UIKit'
   s.osx.framework  = 'AppKit'
 


### PR DESCRIPTION
We cannot actually compile without using Result 1.0.2, and this requires RAC 4.0.1. One could argue that it's actually a dependency on Result, so that should become an added dependency, but I think it may be better to tie ourselves to RAC a little harder, since we depend so heavily on that API.
