### PR TITLE
Added AttributedText to UILabel

### DIFF
--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -14,6 +14,11 @@ extension UILabel {
     public var rex_text: MutableProperty<String> {
         return associatedProperty(self, keyPath: "text")
     }
+    
+    /// Wraps a label's `attributedText` value in a bindable property.
+    public var rex_attributedText: MutableProperty<NSAttributedString?> {
+        return associatedProperty(self, key: &attributedText, initial: { $0.attributedText }, setter: { $0.attributedText = $1 })
+    }
 
     /// Wraps a label's `textColor` value in a bindable property.
     public var rex_textColor: MutableProperty<UIColor> {

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -44,6 +44,30 @@ class UILabelTests: XCTestCase {
         XCTAssertEqual(label.text, secondChange)
     }
     
+    func testAttributedTextPropertyDoesntCreateRetainCycle() {
+        let label = UILabel(frame: CGRectZero)
+        _label = label
+        
+        label.rex_attributedText <~ SignalProducer(value: NSAttributedString(string: "Test"))
+        XCTAssert(_label?.attributedText?.string == "Test")
+    }
+    
+    func testAttributedTextProperty() {
+        let firstChange = NSAttributedString(string: "first")
+        let secondChange = NSAttributedString(string: "second")
+        
+        let label = UILabel(frame: CGRectZero)
+        label.attributedText = NSAttributedString(string: "")
+        
+        let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+        label.rex_attributedText <~ SignalProducer(signal: pipeSignal)
+        
+        observer.sendNext(firstChange)
+        XCTAssertEqual(label.attributedText, firstChange)
+        observer.sendNext(secondChange)
+        XCTAssertEqual(label.attributedText, secondChange)
+    }
+    
     func testTextColorProperty() {
         let firstChange = UIColor.redColor()
         let secondChange = UIColor.blackColor()


### PR DESCRIPTION
I kept the type as `NSAttributedString?`, since it's what a `UILabel` exposes. (if this wasn't clear)
