### PR TITLE
Keys for UILabel associations

### DIFF
--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -17,11 +17,14 @@ extension UILabel {
     
     /// Wraps a label's `attributedText` value in a bindable property.
     public var rex_attributedText: MutableProperty<NSAttributedString?> {
-        return associatedProperty(self, key: &attributedText, initial: { $0.attributedText }, setter: { $0.attributedText = $1 })
+        return associatedProperty(self, key: &attributedTextKey, initial: { $0.attributedText }, setter: { $0.attributedText = $1 })
     }
 
     /// Wraps a label's `textColor` value in a bindable property.
     public var rex_textColor: MutableProperty<UIColor> {
-        return associatedProperty(self, key: &textColor, initial: { $0.textColor }, setter: { $0.textColor = $1 })
+        return associatedProperty(self, key: &textColorKey, initial: { $0.textColor }, setter: { $0.textColor = $1 })
     }
 }
+
+private var attributedTextKey: UInt8 = 0
+private var textColorKey: UInt8 = 0


### PR DESCRIPTION
These were missed when the other extensions were updated to use keys instead of corresponding members which can be problematic (#65).
