### PR TITLE
Fix CocoaPods spec

### DIFF
--- a/Rex.podspec
+++ b/Rex.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'Rex'
   s.module_name  = 'Rex'
-  s.version      = '0.9.0'
+  s.version      = '0.10.0'
   s.summary      = 'ReactiveCocoa Extensions'
 
   s.description  = <<-DESC
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => '0.9.0' }
-  s.dependency 'ReactiveCocoa', '~> 4.0.1'
+  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => s.version }
+  s.dependency 'ReactiveCocoa', '~> 4.1'
   s.ios.framework  = 'UIKit'
   s.osx.framework  = 'AppKit'
 

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.0</string>
+	<string>0.10.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/UIKit/UIDatePicker.swift
+++ b/Source/UIKit/UIDatePicker.swift
@@ -12,7 +12,7 @@ extension UIDatePicker {
     
     public var rex_date: MutableProperty<NSDate> {
         let initial = { (picker: UIDatePicker) -> NSDate in
-            picker.addTarget(self, action: "rex_changedDate", forControlEvents: .ValueChanged)
+            picker.addTarget(self, action: #selector(UIDatePicker.rex_changedDate), forControlEvents: .ValueChanged)
             return picker.date
         }
         return associatedProperty(self, key: &dateKey, initial: initial) { $0.date = $1 }


### PR DESCRIPTION
The last release hasn't updated the podspec accordingly which can be problematic for projects using Rex through CocoaPods. This PR fixes that.

I noticed that #93 already fixes the warning already included in this PR so I can strip that commit if you want.
