### PR TITLE
Dismiss modally

### DIFF
--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		C7932E831C4B3F3000086F3C /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7932E811C4B3EDB00086F3C /* UITextField.swift */; };
 		C7932E841C4B41E100086F3C /* UITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7932E811C4B3EDB00086F3C /* UITextField.swift */; };
 		C7932E871C4B42F500086F3C /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7932E851C4B420A00086F3C /* UITextFieldTests.swift */; };
+		C7945F161CC2D83100DC9E37 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7945F151CC2D83100DC9E37 /* UIViewController.swift */; };
+		C7945F191CC2D88800DC9E37 /* UIViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7945F171CC2D87300DC9E37 /* UIViewControllerTests.swift */; };
 		C7DCE2B41CB3C89A001217D8 /* UITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCE2B21CB3C872001217D8 /* UITextView.swift */; };
 		C7DCE2B71CB3C9D6001217D8 /* UITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCE2B51CB3C9C1001217D8 /* UITextViewTests.swift */; };
 		D8003E941AFEC3D400D7D3C5 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -195,6 +197,8 @@
 		C72CF3E41CBF188A00E19897 /* RACSignal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RACSignal.swift; sourceTree = "<group>"; };
 		C7932E811C4B3EDB00086F3C /* UITextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextField.swift; sourceTree = "<group>"; };
 		C7932E851C4B420A00086F3C /* UITextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextFieldTests.swift; sourceTree = "<group>"; };
+		C7945F151CC2D83100DC9E37 /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
+		C7945F171CC2D87300DC9E37 /* UIViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerTests.swift; sourceTree = "<group>"; };
 		C7DCE2B21CB3C872001217D8 /* UITextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextView.swift; sourceTree = "<group>"; };
 		C7DCE2B51CB3C9C1001217D8 /* UITextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextViewTests.swift; sourceTree = "<group>"; };
 		D8003E921AFEC3D400D7D3C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -411,6 +415,7 @@
 				C7932E811C4B3EDB00086F3C /* UITextField.swift */,
 				C7DCE2B21CB3C872001217D8 /* UITextView.swift */,
 				8289A2E41BD7F6DD0097FB60 /* UIView.swift */,
+				C7945F151CC2D83100DC9E37 /* UIViewController.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -449,6 +454,7 @@
 				C7932E851C4B420A00086F3C /* UITextFieldTests.swift */,
 				C7DCE2B51CB3C9C1001217D8 /* UITextViewTests.swift */,
 				8289A2E61BD7F7730097FB60 /* UIViewTests.swift */,
+				C7945F171CC2D87300DC9E37 /* UIViewControllerTests.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -790,6 +796,7 @@
 				D834572D1AFEE45B0070616A /* Signal.swift in Sources */,
 				D8E4A6211B7BBB2100EAD8A8 /* UIBarItem.swift in Sources */,
 				7D2AA99B1CB6EFEB008AB5C9 /* UISwitch.swift in Sources */,
+				C7945F161CC2D83100DC9E37 /* UIViewController.swift in Sources */,
 				C72CF3E61CBF188A00E19897 /* RACSignal.swift in Sources */,
 				D8A454071BD26A1A00C9E790 /* Property.swift in Sources */,
 				D8E4A6201B7BBB1600EAD8A8 /* UIBarButtonItem.swift in Sources */,
@@ -815,6 +822,7 @@
 				C7932E871C4B42F500086F3C /* UITextFieldTests.swift in Sources */,
 				8295FD8A1B87352D007C9000 /* UIButtonTests.swift in Sources */,
 				D8A4540A1BD2772700C9E790 /* PropertyTests.swift in Sources */,
+				C7945F191CC2D88800DC9E37 /* UIViewControllerTests.swift in Sources */,
 				9DA915A61CA63046003723B9 /* UIDatePickerTests.swift in Sources */,
 				D83457301AFEE45E0070616A /* SignalProducerTests.swift in Sources */,
 				D83457411AFEE6050070616A /* SignalTests.swift in Sources */,

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -24,7 +24,13 @@ extension UIViewController {
         }
         
         let property = associatedProperty(self, key: &dismissModally, initial: initial, setter: setter)
+        
+        property <~ rac_signalForSelector(#selector(UIViewController.dismissViewControllerAnimated(_:completion:)))
+            .takeUntilBlock { _ in property.value != nil }
+            .rex_toTriggerSignal()
+            .map { _ in return nil }
 
+        
         return property
     }
 }

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -1,0 +1,32 @@
+//
+//  UIViewController.swift
+//  Rex
+//
+//  Created by Rui Peres on 14/04/2016.
+//  Copyright © 2016 Neil Pankey. All rights reserved.
+//
+
+import Result
+import ReactiveCocoa
+import UIKit
+
+extension UIViewController {
+    
+    public typealias Completion = (Void -> Void)?
+    public typealias DismissingInformation = (Bool, Completion)?
+    public var rex_dismissModally: MutableProperty<DismissingInformation> {
+        
+        let initial: UIViewController -> DismissingInformation = { _ in nil }
+        let setter: (UIViewController, DismissingInformation) -> Void = { host, dismissingInfo in
+            
+            guard let unwrapped = dismissingInfo else { return }
+            host.dismissViewControllerAnimated(unwrapped.0, completion: unwrapped.1)
+        }
+        
+        let property = associatedProperty(self, key: &dismissModally, initial: initial, setter: setter)
+
+        return property
+    }
+}
+
+private var dismissModally: UInt8 = 0

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -12,15 +12,26 @@ import UIKit
 
 extension UIViewController {
     
-    public typealias Completion = (Void -> Void)?
-    public typealias DismissingInformation = (Bool, Completion)?
-    public var rex_dismissModally: MutableProperty<DismissingInformation> {
+    public typealias DismissingCompletion = (Void -> Void)?
+    public typealias DismissingInformation = (animated: Bool, completion: DismissingCompletion)?
+    
+    /// Wraps a viewController's `dismissViewControllerAnimated` function in a bindable property.
+    /// It mimics the same input as `dismissViewControllerAnimated`: a `Bool` flag for the animation
+    /// and a `(Void -> Void)?` closure for `completion`.
+    /// E.g:
+    /// ```
+    /// //Dismissed with animation (`true`) and `nil` completion
+    /// viewController.rex_dismissAnimated <~ aProducer.map { _ in (true, nil) }
+    /// ```
+    /// The dismissal observation can be made either with binding (example above)
+    /// or `viewController.dismissViewControllerAnimated(true, completion: nil)`
+    public var rex_dismissAnimated: MutableProperty<DismissingInformation> {
         
         let initial: UIViewController -> DismissingInformation = { _ in nil }
         let setter: (UIViewController, DismissingInformation) -> Void = { host, dismissingInfo in
             
             guard let unwrapped = dismissingInfo else { return }
-            host.dismissViewControllerAnimated(unwrapped.0, completion: unwrapped.1)
+            host.dismissViewControllerAnimated(unwrapped.animated, completion: unwrapped.completion)
         }
         
         let property = associatedProperty(self, key: &dismissModally, initial: initial, setter: setter)

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -32,7 +32,7 @@ class UIViewControllerTests: XCTestCase {
             expectation.fulfill()
         }
                 
-        viewController.rex_dismissAnimated <~ SignalProducer(value: (true, nil))
+        viewController.rex_dismissAnimated <~ SignalProducer(value: (animated: true, completion: nil))
     }
     
     func testDismissViewController_via_cocoaDismiss() {

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -28,11 +28,11 @@ class UIViewControllerTests: XCTestCase {
         let viewController = UIViewController()
         _viewController = viewController
         
-        viewController.rex_dismissModally.signal.observeNext { _ in
+        viewController.rex_dismissAnimated.signal.observeNext { _ in
             expectation.fulfill()
         }
                 
-        viewController.rex_dismissModally <~ SignalProducer(value: (true, nil))
+        viewController.rex_dismissAnimated <~ SignalProducer(value: (true, nil))
     }
     
     func testDismissViewController_via_cocoaDismiss() {
@@ -43,7 +43,7 @@ class UIViewControllerTests: XCTestCase {
         let viewController = UIViewController()
         _viewController = viewController
         
-        viewController.rex_dismissModally.signal.observeNext { _ in
+        viewController.rex_dismissAnimated.signal.observeNext { _ in
             expectation.fulfill()
         }
 

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -20,7 +20,7 @@ class UIViewControllerTests: XCTestCase {
         super.tearDown()
     }
     
-    func testDismissViewController() {
+    func testDismissViewController_via_property() {
         
         let expectation = self.expectationWithDescription("Expected rex_dismissModally to be triggered")
         defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
@@ -35,4 +35,18 @@ class UIViewControllerTests: XCTestCase {
         viewController.rex_dismissModally <~ SignalProducer(value: (true, nil))
     }
     
+    func testDismissViewController_via_cocoaDismiss() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_dismissModally to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let viewController = UIViewController()
+        _viewController = viewController
+        
+        viewController.rex_dismissModally.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+
+        viewController.dismissViewControllerAnimated(true, completion: nil)
+    }
 }

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -1,0 +1,38 @@
+//
+//  UIViewControllerTests.swift
+//  Rex
+//
+//  Created by Rui Peres on 16/04/2016.
+//  Copyright © 2016 Neil Pankey. All rights reserved.
+//
+
+import ReactiveCocoa
+import UIKit
+import XCTest
+import enum Result.NoError
+
+class UIViewControllerTests: XCTestCase {
+    
+    weak var _viewController: UIViewController?
+    
+    override func tearDown() {
+        XCTAssert(_viewController == nil, "Retain cycle detected in UIViewController properties")
+        super.tearDown()
+    }
+    
+    func testDismissViewController() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_dismissModally to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let viewController = UIViewController()
+        _viewController = viewController
+        
+        viewController.rex_dismissModally.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+                
+        viewController.rex_dismissModally <~ SignalProducer(value: (true, nil))
+    }
+    
+}


### PR DESCRIPTION
#### What's in this PR

This idea originated from a conversation with @dmcrodrigues, where things like `popToRootViewController` and other ways of manipulating the UI flow, always end with a side effect ( `startWith` and `observe` methods family).  This PR an attempt to make these situation, more idiomatic and declarative. 
#### API

Currently it's using `MutableProperty<(Bool, (Void -> Void)?)?>`, the `Bool` is for the `Animated` flag and the `(Void -> Void)?` for the completion closure. I make the whole tuple an optional to address the `initial` value of a `MutableProperty` (in this case the initial value is `nil`).

 So I would appreciate some feedback on it. cc @mdiep @iv-mexx 
#### How to use it

Currently one would do the following:

``` swift
producer.startWithNext { [weak self] _ in
   self?.dismissViewControllerAnimated(true, completion: nil)
}
```

With this PR:

``` swift
self.rex_dismissModally <~ producer.map { _ in (true, nil) } // where `true` is for the `Animated` flag and `nil` for the completion closure
```
#### Caveat (~~Help needed~~)

There also the cases where one wants to observe the dismiss of a `UIViewController`:

``` swift
viewController.rex_dismissModally.signal.observeNext { _ in

}
```

via:

``` swift
viewController.dismissViewControllerAnimated(true, completion: nil)
```

**I wasn't able to make this work**. I tried the following: 

``` swift

let property = associatedProperty(self, key: &dismissModally, initial: initial, setter: setter)

property <~ rac_signalForSelector(#selector(UIViewController.dismissViewControllerAnimated(_:completion:)))
            .rex_toTriggerSignal()
            .map { _ in nil }

return property
```

This will actually break the test, but it will make the `viewController.dismissViewControllerAnimated(true, completion: nil)` work. 

**Edit1:** This seems to be fixed on c015b963022be178a993504aa36603b998c2c207 
