### PR TITLE
`rac_signalForSelector` for Swift

### DIFF
--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -42,6 +42,7 @@ extension NSObject {
 	/// a runtime call fails, the signal will send an error in the
 	/// RACSelectorSignalErrorDomain.
 	/// It can be used for example to catch `@IBAction func`.
+	@warn_unused_result(message="Did you forget to call `observe` on the signal?")
 	public func rex_signalForSelector(selector: Selector) -> Signal<(AnyObject?, AnyObject?, AnyObject?, AnyObject?, AnyObject?, AnyObject?), NSError> {
 		return self
 			.rac_signalForSelector(selector)

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -34,4 +34,28 @@ extension NSObject {
             .rac_willDeallocSignal()
             .rex_toTriggerSignal()
     }
+	
+	
+	/// Returns a signal which will send a tuple of arguments upon each invocation of
+	/// the selector, then completes when the receiver is deallocated. `next` events
+	/// will be sent synchronously from the thread that invoked the method. If
+	/// a runtime call fails, the signal will send an error in the
+	/// RACSelectorSignalErrorDomain.
+	/// It can be used for example to catch `@IBAction func`.
+	public func rex_signalForSelector(selector: Selector) -> Signal<(AnyObject?, AnyObject?, AnyObject?, AnyObject?, AnyObject?, AnyObject?), NSError> {
+		return self
+			.rac_signalForSelector(selector)
+			.rex_toSignal()
+			.map{
+				let tuple = $0 as? RACTuple
+				guard let first = tuple?.first else		{ return (nil, nil, nil, nil, nil, nil) }
+				guard let second = tuple?.second else	{ return (first, nil, nil, nil, nil, nil) }
+				guard let third = tuple?.third else		{ return (first, second, nil, nil, nil, nil) }
+				guard let fourth = tuple?.fourth else	{ return (first, second, third, nil, nil, nil) }
+				guard let fifth = tuple?.fifth else		{ return (first, second, third, fourth, nil, nil) }
+				guard let last = tuple?.last else		{ return (first, second, third, fourth, fifth, nil) }
+				
+				return (first, second, third, fourth, fifth, last)
+		}
+	}
 }

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -36,6 +36,21 @@ final class NSObjectTests: XCTestCase {
                 expectation.fulfill()
         }
     }
+	
+	func testSignalForSelector(){
+		
+		let expectation = self.expectationWithDescription("Expected rex_signalForSelector when selector will be called.")
+		defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+		
+		let obj = NSObject()
+		
+		obj.rex_signalForSelector(#selector(isEqual(_:)))
+			.observeNext{ _ in
+				expectation.fulfill()
+			}
+		
+		obj.isEqual(nil)
+	}
 }
 
 final class NSObjectDeallocTests: XCTestCase {


### PR DESCRIPTION
I use `rex_signalForSelector(_:)` when I want to use `rac_signalForSelector(_:)`.

Please review 🙇 
### Additional Explanation

I'm sorry for lack of my explanation. `rex_signalForSelector(_:)` can forwards event of selector with attributes. For example, 

``` swift

/// SampleObject (subclass of NSObject)
class SampleObject: NSObject {
    ...
    @IBAction func handleGesture(recognizer: UISwipeGestureRecognizer){}
}

/// Sample2Object
struct Sample2Object {
  let obj: SampleObject

  init(obj: SampleObject) {
    self.obj = obj
    obj.rex_signalForSelector(#selector(SampleObject.handleGesture(_:)))
      .takeUntil(obj.rex_willDeallocSignal)
      .filterMap{ $0.0 as? UISwipeGestureRecognizer }
      .observeNext{ recognizer in    
        switch recognizer.state {
        case .Began:
          ...
        }
      }
  }
}
```
