### PR TITLE
Add completed and started signals to Action

### DIFF
--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		C7945F141CC1DFBE00DC9E37 /* UIViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7945F121CC1DFB400DC9E37 /* UIViewControllerTests.swift */; };
 		C7DCE2B41CB3C89A001217D8 /* UITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCE2B21CB3C872001217D8 /* UITextView.swift */; };
 		C7DCE2B71CB3C9D6001217D8 /* UITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7DCE2B51CB3C9C1001217D8 /* UITextViewTests.swift */; };
+		CC02C18A1CCA704E0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
+		CC02C18B1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
+		CC02C18C1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		D8003E941AFEC3D400D7D3C5 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D8003EB51AFEC6B000D7D3C5 /* Result.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -222,6 +225,7 @@
 		C7945F121CC1DFB400DC9E37 /* UIViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerTests.swift; sourceTree = "<group>"; };
 		C7DCE2B21CB3C872001217D8 /* UITextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextView.swift; sourceTree = "<group>"; };
 		C7DCE2B51CB3C9C1001217D8 /* UITextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextViewTests.swift; sourceTree = "<group>"; };
+		CC02C1881CCA704C0025CC04 /* ActionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionTests.swift; sourceTree = "<group>"; };
 		D8003E921AFEC3D400D7D3C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D8003E931AFEC3D400D7D3C5 /* Rex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rex.h; sourceTree = "<group>"; };
 		D8003E9F1AFEC3D400D7D3C5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -371,6 +375,7 @@
 		D8003E9D1AFEC3D400D7D3C5 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				CC02C1881CCA704C0025CC04 /* ActionTests.swift */,
 				D8A454081BD2772700C9E790 /* PropertyTests.swift */,
 				D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */,
 				D8003EC01AFED30100D7D3C5 /* SignalProducerTests.swift */,
@@ -803,6 +808,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC02C18A1CCA704E0025CC04 /* ActionTests.swift in Sources */,
 				D8F0974A1B17F5E1002E15BA /* NSObjectTests.swift in Sources */,
 				D8003EC21AFED30F00D7D3C5 /* SignalTests.swift in Sources */,
 				D8003EC31AFED30F00D7D3C5 /* SignalProducerTests.swift in Sources */,
@@ -846,6 +852,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC02C18B1CCA704F0025CC04 /* ActionTests.swift in Sources */,
 				7DC325801CC6FD2100746D88 /* UITableViewHeaderFooterViewTests.swift in Sources */,
 				8289A2E11BD7EF1F0097FB60 /* UIImageViewTests.swift in Sources */,
 				D8F0974B1B17F5E2002E15BA /* NSObjectTests.swift in Sources */,
@@ -920,6 +927,7 @@
 				D8715DDE1C211637005F4191 /* SignalProducerTests.swift in Sources */,
 				D8715DE11C211643005F4191 /* UIButtonTests.swift in Sources */,
 				D8715DE21C211643005F4191 /* UIControlTests.swift in Sources */,
+				CC02C18C1CCA704F0025CC04 /* ActionTests.swift in Sources */,
 				D8715DDF1C21163B005F4191 /* NSObjectTests.swift in Sources */,
 				7DC3257E1CC6FD1C00746D88 /* UITableViewCellTests.swift in Sources */,
 				D8715DDC1C211637005F4191 /* PropertyTests.swift in Sources */,

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -16,7 +16,7 @@ extension Action {
     }
 
     /// Whether the action execution was completed succesfully.
-    public var completed: Signal<Void, NoError> {
+    public var rex_completed: Signal<Void, NoError> {
         return events
             .filter { event in
                 if case .Completed = event {
@@ -29,7 +29,7 @@ extension Action {
     }
     
     /// Whether the action execution was started.
-    public var started: Signal<Void, NoError> {
+    public var rex_started: Signal<Void, NoError> {
         return self.executing.signal
             .filter { $0 }
             .map { _ in }

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -15,7 +15,7 @@ extension Action {
         return Action(enabledIf: ConstantProperty(false)) { _ in .empty }
     }
 
-    /// Whether the action execution was completed succesfully.
+    /// Whether the action execution was completed successfully.
     public var rex_completed: Signal<Void, NoError> {
         return events
             .filter { event in

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -14,6 +14,26 @@ extension Action {
     public static var rex_disabled: Action {
         return Action(enabledIf: ConstantProperty(false)) { _ in .empty }
     }
+
+    /// Whether the action execution was completed succesfully.
+    public var completed: Signal<Void, NoError> {
+        return events
+            .filter { event in
+                if case .Completed = event {
+                    return true
+                } else {
+                    return false
+                }
+            }
+            .map { _ in }
+    }
+    
+    /// Whether the action execution was started.
+    public var started: Signal<Void, NoError> {
+        return self.executing.signal
+            .filter { $0 }
+            .map { _ in }
+    }
 }
 
 extension CocoaAction {

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -14,6 +14,13 @@ extension Action {
     public static var rex_disabled: Action {
         return Action(enabledIf: ConstantProperty(false)) { _ in .empty }
     }
+    
+    /// Whether the action execution was started.
+    public var rex_started: Signal<Void, NoError> {
+        return self.executing.signal
+            .filter { $0 }
+            .map { _ in }
+    }
 
     /// Whether the action execution was completed successfully.
     public var rex_completed: Signal<Void, NoError> {
@@ -25,13 +32,6 @@ extension Action {
                     return false
                 }
             }
-            .map { _ in }
-    }
-    
-    /// Whether the action execution was started.
-    public var rex_started: Signal<Void, NoError> {
-        return self.executing.signal
-            .filter { $0 }
             .map { _ in }
     }
 }

--- a/Tests/ActionTests.swift
+++ b/Tests/ActionTests.swift
@@ -33,7 +33,7 @@ final class ActionTests: XCTestCase {
     }
     
     func testCompleted() {
-        let (producer, sink) = SignalProducer<Int, TestError>.buffer(Int.max)
+        let (producer, observer) = SignalProducer<Int, TestError>.buffer(Int.max)
         let action = Action { producer }
 
         var completed = false
@@ -45,15 +45,15 @@ final class ActionTests: XCTestCase {
             .apply()
             .start()
         
-        sink.sendNext(1)
+        observer.sendNext(1)
         XCTAssertFalse(completed)
 
-        sink.sendCompleted()
+        observer.sendCompleted()
         XCTAssertTrue(completed)
     }
     
     func testCompletedOnFailed() {
-        let (producer, sink) = SignalProducer<Int, TestError>.buffer(Int.max)
+        let (producer, observer) = SignalProducer<Int, TestError>.buffer(Int.max)
         let action = Action { producer }
         
         var completed = false
@@ -65,7 +65,7 @@ final class ActionTests: XCTestCase {
             .apply()
             .start()
         
-        sink.sendFailed(.Unknown)
+        observer.sendFailed(.Unknown)
         XCTAssertFalse(completed)
     }
 }

--- a/Tests/ActionTests.swift
+++ b/Tests/ActionTests.swift
@@ -1,0 +1,71 @@
+//
+//  ActionTests.swift
+//  Rex
+//
+//  Created by Ilya Laryionau on 4/20/16.
+//  Copyright © 2016 Neil Pankey. All rights reserved.
+//
+
+@testable import Rex
+import ReactiveCocoa
+import XCTest
+import enum Result.NoError
+
+final class ActionTests: XCTestCase {
+    
+    enum TestError: ErrorType {
+        case Unknown
+    }
+
+    func testStarted() {
+        let action = Action<Void, Void, NoError> { .empty }
+
+        var started = false
+        action
+            .rex_started
+            .observeNext { started = true }
+
+        action
+            .apply()
+            .start()
+
+        XCTAssertTrue(started)
+    }
+    
+    func testCompleted() {
+        let (producer, sink) = SignalProducer<Int, TestError>.buffer(Int.max)
+        let action = Action { producer }
+
+        var completed = false
+        action
+            .rex_completed
+            .observeNext { completed = true }
+
+        action
+            .apply()
+            .start()
+        
+        sink.sendNext(1)
+        XCTAssertFalse(completed)
+
+        sink.sendCompleted()
+        XCTAssertTrue(completed)
+    }
+    
+    func testCompletedOnFailed() {
+        let (producer, sink) = SignalProducer<Int, TestError>.buffer(Int.max)
+        let action = Action { producer }
+        
+        var completed = false
+        action
+            .rex_completed
+            .observeNext { completed = true }
+
+        action
+            .apply()
+            .start()
+        
+        sink.sendFailed(.Unknown)
+        XCTAssertFalse(completed)
+    }
+}


### PR DESCRIPTION
**What's in this pull request?**

This PR adds `completed` and `started` signals to `Action`. I often use empty `Action` as a trigger that some logic should begin executing. So these two properties were introduced. 
