### PR TITLE
UINavigationController's `pop` family

### DIFF
--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		8295FD8D1B87374A007C9000 /* UIBarButtonItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD8B1B873748007C9000 /* UIBarButtonItemTests.swift */; };
 		9DA915A41CA6301C003723B9 /* UIDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA915A31CA6301C003723B9 /* UIDatePicker.swift */; };
 		9DA915A61CA63046003723B9 /* UIDatePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA915A51CA63046003723B9 /* UIDatePickerTests.swift */; };
+		C70361971CCAAF8A001FE20E /* UINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70361961CCAAF8A001FE20E /* UINavigationController.swift */; };
+		C70361991CCAAFC2001FE20E /* UINavigationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70361981CCAAFC2001FE20E /* UINavigationControllerTests.swift */; };
 		C72CF3E51CBF188A00E19897 /* RACSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CF3E41CBF188A00E19897 /* RACSignal.swift */; };
 		C72CF3E61CBF188A00E19897 /* RACSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CF3E41CBF188A00E19897 /* RACSignal.swift */; };
 		C72CF3E71CBF188A00E19897 /* RACSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CF3E41CBF188A00E19897 /* RACSignal.swift */; };
@@ -218,6 +220,8 @@
 		8295FD8B1B873748007C9000 /* UIBarButtonItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarButtonItemTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9DA915A31CA6301C003723B9 /* UIDatePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIDatePicker.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9DA915A51CA63046003723B9 /* UIDatePickerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIDatePickerTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		C70361961CCAAF8A001FE20E /* UINavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationController.swift; sourceTree = "<group>"; };
+		C70361981CCAAFC2001FE20E /* UINavigationControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationControllerTests.swift; sourceTree = "<group>"; };
 		C72CF3E41CBF188A00E19897 /* RACSignal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RACSignal.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C7932E811C4B3EDB00086F3C /* UITextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UITextField.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C7932E851C4B420A00086F3C /* UITextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UITextFieldTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -446,6 +450,7 @@
 				C7DCE2B21CB3C872001217D8 /* UITextView.swift */,
 				8289A2E41BD7F6DD0097FB60 /* UIView.swift */,
 				C7945F101CC192E800DC9E37 /* UIViewController.swift */,
+				C70361961CCAAF8A001FE20E /* UINavigationController.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -488,6 +493,7 @@
 				C7DCE2B51CB3C9C1001217D8 /* UITextViewTests.swift */,
 				8289A2E61BD7F7730097FB60 /* UIViewTests.swift */,
 				C7945F121CC1DFB400DC9E37 /* UIViewControllerTests.swift */,
+				C70361981CCAAFC2001FE20E /* UINavigationControllerTests.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -839,6 +845,7 @@
 				D8E4A6201B7BBB1600EAD8A8 /* UIBarButtonItem.swift in Sources */,
 				D8F097451B17F3C8002E15BA /* NSObject.swift in Sources */,
 				C7945F111CC192E800DC9E37 /* UIViewController.swift in Sources */,
+				C70361971CCAAF8A001FE20E /* UINavigationController.swift in Sources */,
 				D834572E1AFEE45B0070616A /* SignalProducer.swift in Sources */,
 				C7DCE2B41CB3C89A001217D8 /* UITextView.swift in Sources */,
 				8289A2E51BD7F6DD0097FB60 /* UIView.swift in Sources */,
@@ -859,6 +866,7 @@
 				7DCF5B361CC80E8E004AEE75 /* UICollectionReusableViewTests.swift in Sources */,
 				8289A2E81BD7F7900097FB60 /* UIViewTests.swift in Sources */,
 				D8F073161B863CE70047D546 /* UILabelTests.swift in Sources */,
+				C70361991CCAAFC2001FE20E /* UINavigationControllerTests.swift in Sources */,
 				7D2AA99D1CB6F275008AB5C9 /* UISwitchTests.swift in Sources */,
 				C7932E871C4B42F500086F3C /* UITextFieldTests.swift in Sources */,
 				8295FD8A1B87352D007C9000 /* UIButtonTests.swift in Sources */,

--- a/Source/UIKit/UINavigationController.swift
+++ b/Source/UIKit/UINavigationController.swift
@@ -1,0 +1,88 @@
+//
+//  UINavigationController.swift
+//  Rex
+//
+//  Created by Rui Peres on 22/04/2016.
+//  Copyright © 2016 Neil Pankey. All rights reserved.
+//
+
+import enum Result.NoError
+import ReactiveCocoa
+import UIKit
+
+extension UINavigationController {
+    
+    /// Wraps a navigationViewController's `popViewControllerAnimated` function in a bindable property.
+    /// It mimics the same input as `popViewControllerAnimated`: a `Bool` flag for the animation
+    /// E.g:
+    /// ```
+    /// //Pop ViewController with animation (`true`)
+    /// navigationController.rex_popViewController <~ aProducer.map { _ in true }
+    /// ```
+    /// The pop observation can be made either with binding (example above)
+    /// or `viewController.popViewControllerAnimated(true)`
+    public var rex_popViewController: MutableProperty<Bool?> {
+        
+        let initial: UINavigationController -> Bool? = { _ in nil }
+        let setter: (UINavigationController, Bool?) -> Void  = { host, animated in
+            
+            guard let unwrapped = animated else { return }
+            host.popViewControllerAnimated(unwrapped)
+        }
+        
+        let property = associatedProperty(self, key: &popViewController, initial: initial, setter: setter)
+        
+        property <~ rac_signalForSelector(#selector(UINavigationController.popViewControllerAnimated(_:)))
+            .takeUntilBlock { _ in property.value != nil }
+            .rex_toTriggerSignal()
+            .map { _ in return nil }
+        
+        return property
+    }
+    
+    /// Wraps a navigationViewController's `popToRootViewControllerAnimated` function in a bindable property.
+    public var rex_popToRootViewController: MutableProperty<Bool?> {
+        
+        let initial: UINavigationController -> Bool? = { _ in nil }
+        let setter: (UINavigationController, Bool?) -> Void  = { host, animated in
+            
+            guard let unwrapped = animated else { return }
+            host.popToRootViewControllerAnimated(unwrapped)
+        }
+        
+        let property = associatedProperty(self, key: &popToRootViewController, initial: initial, setter: setter)
+        
+        property <~ rac_signalForSelector(#selector(UINavigationController.popToRootViewControllerAnimated(_:)))
+            .takeUntilBlock { _ in property.value != nil }
+            .rex_toTriggerSignal()
+            .map { _ in return nil }
+        
+        return property
+    }
+    
+    public typealias PopToViewController = (viewController: UIViewController, animated: Bool)?
+    
+    /// Wraps a navigationViewController's `popToViewController` function in a bindable property.
+    public var rex_popToViewController: MutableProperty<PopToViewController> {
+        
+        let initial: UINavigationController -> PopToViewController = { _ in nil }
+        let setter: (UINavigationController, PopToViewController) -> Void  = { host, popToViewController in
+            
+            guard let unwrapped = popToViewController else { return }
+            host.popToViewController(unwrapped.viewController, animated: unwrapped.animated)
+        }
+        
+        let property = associatedProperty(self, key: &popToViewControllerKey, initial: initial, setter: setter)
+        
+        property <~ rac_signalForSelector(#selector(UINavigationController.popToViewController(_:animated:)))
+            .takeUntilBlock { _ in property.value != nil }
+            .rex_toTriggerSignal()
+            .map { return nil }
+        
+        return property
+    }
+}
+
+private var popViewController: UInt8 = 0
+private var popToRootViewController: UInt8 = 0
+private var popToViewControllerKey: UInt8 = 0 // can't use `popToViewController` because it conflitcts with `UINavigationController`'s `popToViewController`

--- a/Tests/UIKit/UINavigationControllerTests.swift
+++ b/Tests/UIKit/UINavigationControllerTests.swift
@@ -1,0 +1,120 @@
+//
+//  UINavigationControllerTests.swift
+//  Rex
+//
+//  Created by Rui Peres on 22/04/2016.
+//  Copyright © 2016 Neil Pankey. All rights reserved.
+//
+
+import ReactiveCocoa
+import UIKit
+import XCTest
+import enum Result.NoError
+
+class UINavigationControllerTests: XCTestCase {
+    
+    weak var _navigationController: UINavigationController?
+    
+    override func tearDown() {
+        XCTAssert(_navigationController == nil, "Retain cycle detected in UINavigationController properties")
+        super.tearDown()
+    }
+    
+    func testPopViewController_via_property() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_popViewController to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let navigationController = UINavigationController()
+        _navigationController = navigationController
+        
+        navigationController.rex_popViewController.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+        
+        navigationController.rex_popViewController <~ SignalProducer(value: true)
+    }
+    
+    func testPopViewController_via_cocoa() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_popViewController to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let navigationController = UINavigationController()
+        _navigationController = navigationController
+        
+        navigationController.rex_popViewController.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+        
+        navigationController.popViewControllerAnimated(true)
+    }
+    
+    func testPopToRootViewController_via_property() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_popToRootViewController to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let navigationController = UINavigationController()
+        _navigationController = navigationController
+        
+        navigationController.rex_popToRootViewController.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+        
+        navigationController.rex_popToRootViewController <~ SignalProducer(value: true)
+    }
+    
+    func testPopToRootViewController_via_cocoa() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_popToRootViewController to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let navigationController = UINavigationController()
+        _navigationController = navigationController
+        
+        navigationController.rex_popToRootViewController.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+        
+        navigationController.popToRootViewControllerAnimated(true)
+    }
+    
+    func testPopToViewController_via_property() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_popToViewController to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let navigationController = UINavigationController()
+        _navigationController = navigationController
+        
+        let viewController = UIViewController()
+        navigationController.pushViewController(viewController, animated: false)
+        
+        navigationController.rex_popToViewController.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+        
+        navigationController.rex_popToViewController <~ SignalProducer(value: (viewController, true))
+    }
+    
+    func testPopToViewController_via_cocoa() {
+        
+        let expectation = self.expectationWithDescription("Expected rex_popToViewController to be triggered")
+        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        
+        let navigationController = UINavigationController()
+        _navigationController = navigationController
+        
+        let viewController = UIViewController()
+        navigationController.pushViewController(viewController, animated: false)
+        
+        print(navigationController.viewControllers)
+        
+        navigationController.rex_popToViewController.signal.observeNext { _ in
+            expectation.fulfill()
+        }
+        
+        navigationController.popToViewController(viewController, animated: false)
+    }
+}


### PR DESCRIPTION
(closing #111 due to problems rebasing)

The current issue in this PR is:

All three methods return something. Right now that "something" is not passed to the observer, because it's different from the input.
e.g.:

`rex_popToRootViewController :: MutableProperty<Bool?>`

`popToRootViewControllerAnimated` returns a `[UIViewController],` but we have no way to provide this value for the observers.
