### PR TITLE
Add rex_valueChanged to UISwitch

### DIFF
--- a/Source/UIKit/UISwitch.swift
+++ b/Source/UIKit/UISwitch.swift
@@ -21,7 +21,35 @@ extension UISwitch {
 
         return property
     }
-    
+
+    /// Exposes a property that binds an action into a control's value changed event.
+    ///
+    /// - Important: This also binds the enabled state of the action to the `rex_enabled`
+    /// property on the control.
+    ///
+    /// - Warning: Since iOS 7, `UISwitch` can trigger multiple `.ValueChanged` notifications
+    /// even when there's no change of value. This property observes internally changes on the
+    /// `on` property and manually triggers the action when there's in fact a change of value.
+    /// Because of this, the action will not be set as target of the control.
+    /// [rdar://14485185](https://openradar.appspot.com/14485185)
+    ///
+    public var rex_valueChanged: MutableProperty<CocoaAction> {
+        return associatedObject(self, key: &valueChangedKey) { host in
+            let initial = CocoaAction.rex_disabled
+            let property = MutableProperty(initial)
+
+            host.rex_on
+                .signal
+                .skipRepeats()
+                .combineLatestWith(property.signal)
+                .observeNext { [weak host] _, action in action.execute(host) }
+
+            host.rex_enabled <~ property.producer.flatMap(.Latest) { $0.rex_enabledProducer }
+
+            return property
+        }
+    }
 }
 
 private var onKey: UInt8 = 0
+private var valueChangedKey: UInt8 = 0


### PR DESCRIPTION
## Motivation

I've used a few switches in the last days and I found very useful establishing an action to act immediately upon the change of the switch but also controlling the enabled state automatically.
## Description

I created this new property highly inspired in the implementation of `rex_pressed` and everything worked as expected. However, there's an issue since iOS 7 where a switch can trigger multiple notifications of value changed even when there's not a change of switch's state, [rdar://14485185](https://openradar.appspot.com/14485185). I changed the implementation a bit to adopt internal observation of changes and trigger the action manually only when there's in fact a change to achieve the originally expected behaviour.

I'm not happy with this but the issue is real and undesirable so I decided to contribute it because probably this may be useful to others facing this particular problem.

In case of positive feedback, I'll try to invest some time in a way to test it since apparently we cannot manually trigger `.ValueChanged` events for controls beyond `UIButton`.
