### PR TITLE
Make `UITextField.rex_text` send on all editing events

### DIFF
--- a/Source/UIKit/UITextField.swift
+++ b/Source/UIKit/UITextField.swift
@@ -14,8 +14,7 @@ extension UITextField {
     
     /// Sends the field's string value whenever it changes.
     public var rex_text: SignalProducer<String, NoError> {
-        return NSNotificationCenter.defaultCenter()
-            .rac_notifications(UITextFieldTextDidChangeNotification, object: self)
-            .filterMap  { ($0.object as? UITextField)?.text }
+        return rex_controlEvents(.AllEditingEvents)
+            .filterMap  { ($0 as? UITextField)?.text }
     }
 }


### PR DESCRIPTION
This solves some issues around keyboard shortcuts and autocomplete.
See: https://github.com/ReactiveCocoa/ReactiveCocoa/pull/1767
