### PR TITLE
Update Podspec to use RAC 4.2.1

### DIFF
--- a/Rex.podspec
+++ b/Rex.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'Rex'
   s.module_name  = 'Rex'
-  s.version      = '0.10.0'
+  s.version      = '0.11.0'
   s.summary      = 'ReactiveCocoa Extensions'
 
   s.description  = <<-DESC

--- a/Rex.podspec
+++ b/Rex.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => '0.11.0-beta.1' }
+  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => s.version }
   s.dependency 'ReactiveCocoa', '~> 4.2.1'
   s.ios.framework  = 'UIKit'
   s.tvos.framework = 'UIKit'

--- a/Rex.podspec
+++ b/Rex.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
                    Extensions for ReactiveCocoa that may not fit in the core framework.
                    DESC
 
-  s.homepage     = 'https://github.com/neilpa/Rex'
+  s.homepage     = 'https://github.com/RACCommunity/Rex'
   s.license      = 'MIT'
 
   s.author             = { 'Neil Pankey' => 'npankey@gmail.com' }
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => s.version }
+  s.source       = { :git => 'https://github.com/RACCommunity/Rex.git', :tag => s.version }
   s.dependency 'ReactiveCocoa', '~> 4.2.1'
   s.ios.framework  = 'UIKit'
   s.tvos.framework = 'UIKit'

--- a/Rex.podspec
+++ b/Rex.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = 'Rex'
   s.module_name  = 'Rex'
-  s.version      = '0.11.0'
+  s.version      = '0.11.0-beta.1'
   s.summary      = 'ReactiveCocoa Extensions'
 
   s.description  = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :commit => '265e8e9c9503bc917ee5af5252590ab38eda4bff' }
+  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => '0.11.0-beta.1' }
   s.dependency 'ReactiveCocoa', '~> 4.2.1'
   s.ios.framework  = 'UIKit'
   s.tvos.framework = 'UIKit'

--- a/Rex.podspec
+++ b/Rex.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
-  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :tag => s.version }
-  s.dependency 'ReactiveCocoa', '~> 4.1'
+  s.source       = { :git => 'https://github.com/neilpa/Rex.git', :commit => '265e8e9c9503bc917ee5af5252590ab38eda4bff' }
+  s.dependency 'ReactiveCocoa', '~> 4.2.1'
   s.ios.framework  = 'UIKit'
   s.tvos.framework = 'UIKit'
   s.osx.framework  = 'AppKit'


### PR DESCRIPTION
Maybe a version bump and/or a release would be better than applying a
defined commit number.
