### PR TITLE
Changed `rex_text` bindable property to be an optional string

### DIFF
--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -11,8 +11,8 @@ import UIKit
 
 extension UILabel {
     /// Wraps a label's `text` value in a bindable property.
-    public var rex_text: MutableProperty<String> {
-        return associatedProperty(self, keyPath: "text")
+    public var rex_text: MutableProperty<String?> {
+        return associatedProperty(self, key: &attributedTextKey, initial: { $0.text }, setter: { $0.text = $1 })
     }
     
     /// Wraps a label's `attributedText` value in a bindable property.
@@ -26,5 +26,6 @@ extension UILabel {
     }
 }
 
+private var textKey: UInt8 = 0
 private var attributedTextKey: UInt8 = 0
 private var textColorKey: UInt8 = 0

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -36,7 +36,7 @@ class UILabelTests: XCTestCase {
         label.text = ""
         
         let (pipeSignal, observer) = Signal<String, NoError>.pipe()
-        label.rex_text <~ SignalProducer(signal: pipeSignal)
+        label.rex_text <~ SignalProducer(signal: pipeSignal).producer.map(Optional.init) // TODO: Remove in the future, binding with optionals will be available soon in RAC
         
         observer.sendNext(firstChange)
         XCTAssertEqual(label.text, firstChange)

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -35,13 +35,15 @@ class UILabelTests: XCTestCase {
         let label = UILabel(frame: CGRectZero)
         label.text = ""
         
-        let (pipeSignal, observer) = Signal<String, NoError>.pipe()
-        label.rex_text <~ SignalProducer(signal: pipeSignal).producer.map(Optional.init) // TODO: Remove in the future, binding with optionals will be available soon in RAC
+        let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
+        label.rex_text <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(firstChange)
         XCTAssertEqual(label.text, firstChange)
         observer.sendNext(secondChange)
         XCTAssertEqual(label.text, secondChange)
+        observer.sendNext(nil)
+        XCTAssertNil(label.text)
     }
     
     func testAttributedTextPropertyDoesntCreateRetainCycle() {

--- a/Tests/UIKit/UITableViewCellTests.swift
+++ b/Tests/UIKit/UITableViewCellTests.swift
@@ -24,6 +24,7 @@ class UITableViewCellTests: XCTestCase {
         label.rex_text <~
             titleProperty
                 .producer
+                .map(Optional.init) // TODO: Remove in the future, binding with optionals will be available soon in RAC
                 .takeUntil(cell.rex_prepareForReuse)
 
         XCTAssertEqual(label.text, "John")

--- a/Tests/UIKit/UITableViewCellTests.swift
+++ b/Tests/UIKit/UITableViewCellTests.swift
@@ -24,7 +24,7 @@ class UITableViewCellTests: XCTestCase {
         label.rex_text <~
             titleProperty
                 .producer
-                .map(Optional.init) // TODO: Remove in the future, binding with optionals will be available soon in RAC
+                .map(Optional.init) // TODO: Remove in the future, binding with optionals will be available soon in RAC 5. Reference: https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2852
                 .takeUntil(cell.rex_prepareForReuse)
 
         XCTAssertEqual(label.text, "John")


### PR DESCRIPTION
Fixes #125, #129.
### Discussion

This no longer relies on KVC, I think this promotes code consistency since other properties are not using it either. It also helps avoiding a battle with a weakly typed system where everything needs to be `AnyObject`.
