### PR TITLE
Swift 3 enablement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
   - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c
   - xcodebuild build -scheme Rex-watchOS -sdk watchsimulator -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" | xcpretty -c
-  - pod lib lint --allow-warnings
+  - pod lib lint --quick --allow-warnings
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ git:
 
 script:
   - set -o pipefail
-  - carthage bootstrap
+  - carthage bootstrap --no-use-binaries
   - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-Mac | xcpretty -c
   - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
   - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 matrix:
   include:
-    - osx_image: xcode7.3
+    - osx_image: xcode8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - xcodebuild test -scheme Rex-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
   - xcodebuild test -scheme Rex-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c
   - xcodebuild build -scheme Rex-watchOS -sdk watchsimulator -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" | xcpretty -c
-  - pod lib lint
+  - pod lib lint --allow-warnings
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,25 @@ language: objective-c
 matrix:
   include:
     - osx_image: xcode7.3
-      env:
-        - XCODEBUILD_TEST_ACTION="test"
+      env: PLATFORM=Mac
+    - osx_image: xcode7.3
+      env: PLATFORM=iOS
+    - osx_image: xcode7.3
+      env: PLATFORM=tvOS
+    - osx_image: xcode7.3
+      env: PLATFORM=watchOS
+    - osx_image: xcode7.3
+      env: PLATFORM=CocoaPods
     - osx_image: xcode8
-      env:
-        - XCODEBUILD_TEST_ACTION="build-for-testing test-without-building"
+      env: PLATFORM=Mac TEST_ACTION="build-for-testing test-without-building"
+    - osx_image: xcode8
+      env: PLATFORM=iOS TEST_ACTION="build-for-testing test-without-building"
+    - osx_image: xcode8
+      env: PLATFORM=tvOS TEST_ACTION="build-for-testing test-without-building"
+    - osx_image: xcode8
+      env: PLATFORM=watchOS TEST_ACTION="build-for-testing test-without-building"
+    - osx_image: xcode8
+      env: PLATFORM=CocoaPods
 
 env:
   global:
@@ -15,14 +29,7 @@ env:
 git:
   submodules: false
 
-script:
-  - set -o pipefail
-  - carthage bootstrap --no-use-binaries
-  - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-Mac | xcpretty -c
-  - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
-  - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c
-  - xcodebuild build -scheme Rex-watchOS -sdk watchsimulator -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" | xcpretty -c
-  - pod lib lint --quick --allow-warnings
+script: script/ci "$PLATFORM"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ language: objective-c
 matrix:
   include:
     - osx_image: xcode7.3
+      env:
+        - XCODEBUILD_TEST_ACTION="test"
     - osx_image: xcode8
+      env:
+        - XCODEBUILD_TEST_ACTION="build-for-testing test-without-building"
 
 env:
   global:
@@ -14,9 +18,9 @@ git:
 script:
   - set -o pipefail
   - carthage bootstrap
-  - xcodebuild test -scheme Rex-Mac | xcpretty -c
-  - xcodebuild test -scheme Rex-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
-  - xcodebuild test -scheme Rex-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c
+  - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-Mac | xcpretty -c
+  - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-iOS -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
+  - xcodebuild $XCODEBUILD_TEST_ACTION -scheme Rex-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c
   - xcodebuild build -scheme Rex-watchOS -sdk watchsimulator -destination "platform=watchOS Simulator,name=Apple Watch - 38mm" | xcpretty -c
   - pod lib lint --allow-warnings
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: objective-c
 matrix:
   include:
     - osx_image: xcode7.3
+    - osx_image: xcode8
 
 env:
   global:

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveCocoa" "RAC5-swift3"
+github "ReactiveCocoa/ReactiveCocoa" "RAC5"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveCocoa" "RAC5"
+github "ReactiveCocoa/ReactiveCocoa" "master"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveCocoa" ~> 4.2.1
+github "ReactiveCocoa/ReactiveCocoa" "RAC5-swift3"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveCocoa" ~> 4.2.1
+github "ReactiveCocoa/ReactiveCocoa" ~> 4.2.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "2fe88d1d41615ed060489e8cd06fc1b3e8f0ca53"
-github "ReactiveCocoa/ReactiveCocoa" "3073a487acd53008a41b89ef6512040a1347212d"
+github "antitypical/Result" "7d9c3ac21f22aaece85d37a0fc55ebd1eddf4df4"
+github "ReactiveCocoa/ReactiveCocoa" "c495401c16fe4c4d495563b5520feba0cf8d53f2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "2.1.1"
-github "ReactiveCocoa/ReactiveCocoa" "v4.2.1"
+github "antitypical/Result" "2.1.3"
+github "ReactiveCocoa/ReactiveCocoa" "v4.2.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "7d9c3ac21f22aaece85d37a0fc55ebd1eddf4df4"
-github "ReactiveCocoa/ReactiveCocoa" "c495401c16fe4c4d495563b5520feba0cf8d53f2"
+github "antitypical/Result" "8f1affd40bc2b10a15f56ff6cb7b00639e29cb35"
+github "ReactiveCocoa/ReactiveCocoa" "ce2ace70893193a5f2e0eadea89ed3a013d0a8b0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "antitypical/Result" "8f1affd40bc2b10a15f56ff6cb7b00639e29cb35"
-github "ReactiveCocoa/ReactiveCocoa" "ce2ace70893193a5f2e0eadea89ed3a013d0a8b0"
+github "ReactiveCocoa/ReactiveCocoa" "812d978a1d9c1c262c7996e111de30ee4233b463"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "2.1.1"
-github "ReactiveCocoa/ReactiveCocoa" "v4.2.1"
+github "antitypical/Result" "2fe88d1d41615ed060489e8cd06fc1b3e8f0ca53"
+github "ReactiveCocoa/ReactiveCocoa" "3073a487acd53008a41b89ef6512040a1347212d"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "8f1affd40bc2b10a15f56ff6cb7b00639e29cb35"
-github "ReactiveCocoa/ReactiveCocoa" "8213f2e47c3228ad1895bf74c9b6dba541a45aa7"
+github "jameshurst/Result" "2401fa7584183da17f40335816073bf511fb34b8"
+github "ReactiveCocoa/ReactiveCocoa" "b4d757433574f85519bb3253a631955da937106a"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "jameshurst/Result" "2401fa7584183da17f40335816073bf511fb34b8"
-github "ReactiveCocoa/ReactiveCocoa" "b4d757433574f85519bb3253a631955da937106a"
+github "antitypical/Result" "3.0.0-alpha.2"
+github "ReactiveCocoa/ReactiveCocoa" "d98489ae97b020ccdd9a8c8ccad2b67429817669"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "antitypical/Result" "8f1affd40bc2b10a15f56ff6cb7b00639e29cb35"
-github "ReactiveCocoa/ReactiveCocoa" "812d978a1d9c1c262c7996e111de30ee4233b463"
+github "ReactiveCocoa/ReactiveCocoa" "8213f2e47c3228ad1895bf74c9b6dba541a45aa7"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
-github "antitypical/Result" "3.0.0-alpha.3"
-github "ReactiveCocoa/ReactiveCocoa" "b711611ad9906b1bfc5027824f57a2889e34204d"
+github "antitypical/Result" "3.0.0"
+github "ReactiveCocoa/ReactiveSwift" "598ce311be21911d3d365c6b9c5245fdc9e72394"
+github "ReactiveCocoa/ReactiveCocoa" "26997cf6f0eda7d64b76ba82013525e6ab900e8e"

--- a/Deprecations+Removals.swift
+++ b/Deprecations+Removals.swift
@@ -39,7 +39,7 @@ extension Data {
     public static func rex_dataWithContentsOfURL(_ url: URL, options: Data.ReadingOptions = []) -> SignalProducer<Data, NSError> { fatalError() }
 }
 
-extension NSData {
+extension Data {
     @available(*, unavailable, renamed:"rex_data(contentsOf:options:)")
     public static func rex_dataWithContentsOfURL(_ url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> { fatalError() }
 }

--- a/Deprecations+Removals.swift
+++ b/Deprecations+Removals.swift
@@ -1,4 +1,5 @@
 // MARK: Renamed APIs in Swift 3.0
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Deprecations+Removals.swift
+++ b/Deprecations+Removals.swift
@@ -1,0 +1,45 @@
+// MARK: Renamed APIs in Swift 3.0
+import ReactiveCocoa
+import enum Result.NoError
+
+extension SignalProtocol {
+    @available(*, unavailable, renamed:"mute(for:clock:)")
+    public func muteFor(_ interval: TimeInterval, clock: DateSchedulerProtocol) -> Signal<Value, Error> { fatalError() }
+
+    @available(*, unavailable, renamed:"timeout(after:with:on:)")
+    public func timeoutAfter(_ interval: TimeInterval, withEvent event: Event<Value, Error>, onScheduler scheduler: DateSchedulerProtocol) -> Signal<Value, Error> { fatalError() }
+}
+
+extension SignalProducerProtocol {
+    @available(*, unavailable, renamed:"mute(for:clock:)")
+    public func muteFor(_ interval: TimeInterval, clock: DateSchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
+
+    @available(*, unavailable, renamed:"timeout(after:with:on:)")
+    public func timeoutAfter(_ interval: TimeInterval, withEvent event: Event<Value, Error>, onScheduler scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
+
+    @available(*, unavailable, renamed:"group(by:)")
+    public func groupBy<Key: Hashable>(_ grouping: (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> { fatalError() }
+
+    @available(*, unavailable, renamed:"defer(by:on:)")
+    public func deferred(_ interval: TimeInterval, onScheduler scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> { fatalError() }
+}
+
+extension UserDefaults {
+    @available(*, unavailable, renamed:"rex_value(forKey:)")
+    public func rex_valueForKey(_ key: String) -> SignalProducer<AnyObject?, NoError> { fatalError() }
+}
+
+extension NSObject {
+    @available(*, unavailable, renamed:"rex_producer(forKeyPath:)")
+    public func rex_producerForKeyPath<T>(_ keyPath: String) -> SignalProducer<T, NoError> { fatalError() }
+}
+
+extension Data {
+    @available(*, unavailable, renamed:"rex_data(contentsOf:options:)")
+    public static func rex_dataWithContentsOfURL(_ url: URL, options: Data.ReadingOptions = []) -> SignalProducer<Data, NSError> { fatalError() }
+}
+
+extension NSData {
+    @available(*, unavailable, renamed:"rex_data(contentsOf:options:)")
+    public static func rex_dataWithContentsOfURL(_ url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> { fatalError() }
+}

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -56,8 +56,8 @@
 		CC02C18B1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		CC02C18C1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		D8003E941AFEC3D400D7D3C5 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D8003EB51AFEC6B000D7D3C5 /* Result.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8003EB51AFEC6B000D7D3C5 /* Result.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EB81AFEC7A900D7D3C5 /* SignalProducer.swift */; };
 		D8003EBD1AFED01000D7D3C5 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBC1AFED01000D7D3C5 /* Signal.swift */; };
 		D8003EC21AFED30F00D7D3C5 /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
@@ -71,8 +71,8 @@
 		D83457331AFEE4930070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; };
 		D83457351AFEE4B20070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
 		D83457361AFEE4B20070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
-		D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
-		D834573A1AFEE4BE0070616A /* Result.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
+		D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
+		D834573A1AFEE4BE0070616A /* Result.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
 		D834573C1AFEE57E0070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
 		D834573D1AFEE57E0070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
 		D83457411AFEE6050070616A /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
@@ -90,9 +90,9 @@
 		D8715DA11C211011005F4191 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8715DA21C211014005F4191 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D8715DA31C21107F005F4191 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
-		D8715DA41C21107F005F4191 /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
+		D8715DA41C21107F005F4191 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* Data.swift */; };
 		D8715DA51C21107F005F4191 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097431B17F3C8002E15BA /* NSObject.swift */; };
-		D8715DA61C21107F005F4191 /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
+		D8715DA61C21107F005F4191 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* UserDefaults.swift */; };
 		D8715DA91C2110DA005F4191 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DA71C2110DA005F4191 /* ReactiveCocoa.framework */; };
 		D8715DAA1C2110DA005F4191 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DA81C2110DA005F4191 /* Result.framework */; };
 		D8715DB91C2112A9005F4191 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -101,9 +101,9 @@
 		D8715DBC1C2112D1005F4191 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBC1AFED01000D7D3C5 /* Signal.swift */; };
 		D8715DBD1C2112D1005F4191 /* SignalProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EB81AFEC7A900D7D3C5 /* SignalProducer.swift */; };
 		D8715DBE1C2112D6005F4191 /* Association.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86FFBD01B34AD6F001A89B3 /* Association.swift */; };
-		D8715DBF1C2112D6005F4191 /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
+		D8715DBF1C2112D6005F4191 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* Data.swift */; };
 		D8715DC01C2112D6005F4191 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097431B17F3C8002E15BA /* NSObject.swift */; };
-		D8715DC11C2112D6005F4191 /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
+		D8715DC11C2112D6005F4191 /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* UserDefaults.swift */; };
 		D8715DC41C211310005F4191 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
 		D8715DC51C211310005F4191 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
 		D8715DC61C211553005F4191 /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173EBC71B625A6800C9B48E /* UIBarButtonItem.swift */; };
@@ -125,8 +125,8 @@
 		D8715DE51C211643005F4191 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8289A2E61BD7F7730097FB60 /* UIViewTests.swift */; };
 		D8715DE61C21170C005F4191 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
 		D8715DE71C21170C005F4191 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
-		D8715DE91C211739005F4191 /* ReactiveCocoa.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
-		D8715DEA1C211739005F4191 /* Result.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
+		D8715DE91C211739005F4191 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
+		D8715DEA1C211739005F4191 /* Result.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
 		D8A454061BD26A1A00C9E790 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A454051BD26A1A00C9E790 /* Property.swift */; };
 		D8A454071BD26A1A00C9E790 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A454051BD26A1A00C9E790 /* Property.swift */; };
 		D8A454091BD2772700C9E790 /* PropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A454081BD2772700C9E790 /* PropertyTests.swift */; };
@@ -134,18 +134,18 @@
 		D8E4A6201B7BBB1600EAD8A8 /* UIBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173EBC71B625A6800C9B48E /* UIBarButtonItem.swift */; };
 		D8E4A6211B7BBB2100EAD8A8 /* UIBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5173EBC51B625A2600C9B48E /* UIBarItem.swift */; };
 		D8F073161B863CE70047D546 /* UILabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F073141B861B3A0047D546 /* UILabelTests.swift */; };
-		D8F0973B1B17F2F7002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
-		D8F0973D1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
-		D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */; };
-		D8F0973F1B17F31E002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
+		D8F0973B1B17F2F7002E15BA /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* Data.swift */; };
+		D8F0973D1B17F30D002E15BA /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* UserDefaults.swift */; };
+		D8F0973E1B17F30D002E15BA /* UserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973C1B17F30D002E15BA /* UserDefaults.swift */; };
+		D8F0973F1B17F31E002E15BA /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* Data.swift */; };
 		D8F097441B17F3C8002E15BA /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097431B17F3C8002E15BA /* NSObject.swift */; };
 		D8F097451B17F3C8002E15BA /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097431B17F3C8002E15BA /* NSObject.swift */; };
+		D8F0974A1B17F5E1002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
+		D8F0974B1B17F5E2002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
 		E6933BEA1CD9C335006F7CE7 /* UIProgressViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */; };
 		E6933BEB1CD9C363006F7CE7 /* UIProgressViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */; };
 		E6933BEC1CD9C37D006F7CE7 /* UIProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */; };
 		E6933BED1CD9C37D006F7CE7 /* UIProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */; };
-		D8F0974A1B17F5E1002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
-		D8F0974B1B17F5E2002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -173,49 +173,50 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		D8003EB21AFEC6A800D7D3C5 /* (null) */ = {
+		D8003EB21AFEC6A800D7D3C5 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
-				D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in (null) */,
-				D8003EB51AFEC6B000D7D3C5 /* Result.framework in (null) */,
+				D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in Copy Files */,
+				D8003EB51AFEC6B000D7D3C5 /* Result.framework in Copy Files */,
+			);
+			name = "Copy Files";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D83457371AFEE4B80070616A /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+				D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in CopyFiles */,
+				D834573A1AFEE4BE0070616A /* Result.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D83457371AFEE4B80070616A /* (null) */ = {
+		D8715DE81C21172A005F4191 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
-				D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in (null) */,
-				D834573A1AFEE4BE0070616A /* Result.framework in (null) */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D8715DE81C21172A005F4191 /* (null) */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 16;
-			files = (
-				D8715DE91C211739005F4191 /* ReactiveCocoa.framework in (null) */,
-				D8715DEA1C211739005F4191 /* Result.framework in (null) */,
+				D8715DE91C211739005F4191 /* ReactiveCocoa.framework in CopyFiles */,
+				D8715DEA1C211739005F4191 /* Result.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4238D5951B4D5950008534C0 /* NSTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NSTextField.swift; path = AppKit/NSTextField.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		45CED46B1D27BB8700788BDC /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
 		45CED46D1D27C1D400788BDC /* UIActivityIndicatorViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorViewTests.swift; sourceTree = "<group>"; };
-		4238D5951B4D5950008534C0 /* NSTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NSTextField.swift; path = AppKit/NSTextField.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		5B1C882D1D0715CE000B888F /* UISegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControl.swift; sourceTree = "<group>"; };
-		5B1C882F1D071639000B888F /* UISegmentedControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControlTests.swift; sourceTree = "<group>"; };
 		5173EBC51B625A2600C9B48E /* UIBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarItem.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5173EBC71B625A6800C9B48E /* UIBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarButtonItem.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B1C882D1D0715CE000B888F /* UISegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControl.swift; sourceTree = "<group>"; };
+		5B1C882F1D071639000B888F /* UISegmentedControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControlTests.swift; sourceTree = "<group>"; };
 		7D0DABA91CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+EnableSendActionsForControlEvents.swift"; sourceTree = "<group>"; };
 		7D2AA99A1CB6EFEB008AB5C9 /* UISwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UISwitch.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		7D2AA99C1CB6F275008AB5C9 /* UISwitchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UISwitchTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -273,12 +274,12 @@
 		D8A454051BD26A1A00C9E790 /* Property.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Property.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8A454081BD2772700C9E790 /* PropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PropertyTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F073141B861B3A0047D546 /* UILabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UILabelTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		D8F0973A1B17F2F7002E15BA /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSData.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressView.swift; sourceTree = "<group>"; };
-		E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewTests.swift; sourceTree = "<group>"; };
-		D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSUserDefaults.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D8F0973A1B17F2F7002E15BA /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Data.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D8F0973C1B17F30D002E15BA /* UserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UserDefaults.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F097431B17F3C8002E15BA /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSObject.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F097471B17F5DD002E15BA /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSObjectTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressView.swift; sourceTree = "<group>"; };
+		E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -371,7 +372,10 @@
 				D8003E9D1AFEC3D400D7D3C5 /* Tests */,
 				D8003EAA1AFEC57200D7D3C5 /* Binaries */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 0;
 		};
 		D8003E901AFEC3D400D7D3C5 /* Source */ = {
 			isa = PBXGroup;
@@ -530,9 +534,9 @@
 			isa = PBXGroup;
 			children = (
 				D86FFBD01B34AD6F001A89B3 /* Association.swift */,
-				D8F0973A1B17F2F7002E15BA /* NSData.swift */,
+				D8F0973A1B17F2F7002E15BA /* Data.swift */,
 				D8F097431B17F3C8002E15BA /* NSObject.swift */,
-				D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */,
+				D8F0973C1B17F30D002E15BA /* UserDefaults.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -608,7 +612,7 @@
 				D8003E951AFEC3D400D7D3C5 /* Sources */,
 				D8003E961AFEC3D400D7D3C5 /* Frameworks */,
 				D8003E971AFEC3D400D7D3C5 /* Resources */,
-				D8003EB21AFEC6A800D7D3C5 /* (null) */,
+				D8003EB21AFEC6A800D7D3C5 /* Copy Files */,
 			);
 			buildRules = (
 			);
@@ -645,7 +649,7 @@
 				D834571A1AFEE44E0070616A /* Sources */,
 				D834571B1AFEE44E0070616A /* Frameworks */,
 				D834571C1AFEE44E0070616A /* Resources */,
-				D83457371AFEE4B80070616A /* (null) */,
+				D83457371AFEE4B80070616A /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -700,7 +704,7 @@
 				D8715DCD1C21160A005F4191 /* Sources */,
 				D8715DCE1C21160A005F4191 /* Frameworks */,
 				D8715DCF1C21160A005F4191 /* Resources */,
-				D8715DE81C21172A005F4191 /* (null) */,
+				D8715DE81C21172A005F4191 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -719,7 +723,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Neil Pankey";
 				TargetAttributes = {
 					D8003E8D1AFEC3D400D7D3C5 = {
@@ -745,7 +749,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex-Mac" */;
+			buildConfigurationList = D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -832,9 +836,9 @@
 				D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */,
 				D8003EBD1AFED01000D7D3C5 /* Signal.swift in Sources */,
 				D8F097441B17F3C8002E15BA /* NSObject.swift in Sources */,
-				D8F0973B1B17F2F7002E15BA /* NSData.swift in Sources */,
+				D8F0973B1B17F2F7002E15BA /* Data.swift in Sources */,
 				4238D5961B4D5950008534C0 /* NSTextField.swift in Sources */,
-				D8F0973D1B17F30D002E15BA /* NSUserDefaults.swift in Sources */,
+				D8F0973D1B17F30D002E15BA /* UserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -864,7 +868,7 @@
 				7DC325741CC6FCF100746D88 /* UITableViewCell.swift in Sources */,
 				5B7F81E31D0842AD0014B06D /* UISegmentedControl.swift in Sources */,
 				8289A2E31BD7EF740097FB60 /* UIImageView.swift in Sources */,
-				D8F0973E1B17F30D002E15BA /* NSUserDefaults.swift in Sources */,
+				D8F0973E1B17F30D002E15BA /* UserDefaults.swift in Sources */,
 				D834572D1AFEE45B0070616A /* Signal.swift in Sources */,
 				D8E4A6211B7BBB2100EAD8A8 /* UIBarItem.swift in Sources */,
 				7D2AA99B1CB6EFEB008AB5C9 /* UISwitch.swift in Sources */,
@@ -879,7 +883,7 @@
 				C7DCE2B41CB3C89A001217D8 /* UITextView.swift in Sources */,
 				8289A2E51BD7F6DD0097FB60 /* UIView.swift in Sources */,
 				D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */,
-				D8F0973F1B17F31E002E15BA /* NSData.swift in Sources */,
+				D8F0973F1B17F31E002E15BA /* Data.swift in Sources */,
 				D86FFBDD1B34B691001A89B3 /* UIButton.swift in Sources */,
 				45CED4711D27C1EB00788BDC /* UIActivityIndicatorView.swift in Sources */,
 				7D0DABAA1CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift in Sources */,
@@ -925,9 +929,9 @@
 				D8715DA51C21107F005F4191 /* NSObject.swift in Sources */,
 				D8715D9F1C210FF9005F4191 /* Signal.swift in Sources */,
 				C72CF3E81CBF188A00E19897 /* RACSignal.swift in Sources */,
-				D8715DA41C21107F005F4191 /* NSData.swift in Sources */,
+				D8715DA41C21107F005F4191 /* Data.swift in Sources */,
 				D8715D9D1C210FF9005F4191 /* Action.swift in Sources */,
-				D8715DA61C21107F005F4191 /* NSUserDefaults.swift in Sources */,
+				D8715DA61C21107F005F4191 /* UserDefaults.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -951,12 +955,12 @@
 				D8715DBC1C2112D1005F4191 /* Signal.swift in Sources */,
 				C72CF3E71CBF188A00E19897 /* RACSignal.swift in Sources */,
 				E6933BED1CD9C37D006F7CE7 /* UIProgressView.swift in Sources */,
-				D8715DBF1C2112D6005F4191 /* NSData.swift in Sources */,
+				D8715DBF1C2112D6005F4191 /* Data.swift in Sources */,
 				D8715DCC1C211553005F4191 /* UIView.swift in Sources */,
 				D8715DBA1C2112D1005F4191 /* Action.swift in Sources */,
 				D8715DC81C211553005F4191 /* UIButton.swift in Sources */,
 				D8715DC71C211553005F4191 /* UIBarItem.swift in Sources */,
-				D8715DC11C2112D6005F4191 /* NSUserDefaults.swift in Sources */,
+				D8715DC11C2112D6005F4191 /* UserDefaults.swift in Sources */,
 				45CED4721D27C1EC00788BDC /* UIActivityIndicatorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1043,6 +1047,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1083,6 +1088,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
@@ -1109,7 +1115,6 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.neilpa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
@@ -1135,10 +1140,10 @@
 				INFOPLIST_FILE = Source/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "me.neilpa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -1175,6 +1180,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.neilpa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
 		};
@@ -1231,6 +1237,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1274,6 +1281,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.neilpa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1321,6 +1329,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 4;
 				VALIDATE_PRODUCT = YES;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -1370,6 +1379,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -1404,6 +1414,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.neilpa.RexTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1412,7 +1423,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex-Mac" */ = {
+		D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D8003EA21AFEC3D400D7D3C5 /* Debug */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -39,6 +39,10 @@
 		8295FD871B87309F007C9000 /* UIControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD851B873081007C9000 /* UIControlTests.swift */; };
 		8295FD8A1B87352D007C9000 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD881B873490007C9000 /* UIButtonTests.swift */; };
 		8295FD8D1B87374A007C9000 /* UIBarButtonItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD8B1B873748007C9000 /* UIBarButtonItemTests.swift */; };
+		9A5492121D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
+		9A5492131D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
+		9A5492141D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
+		9A5492151D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
 		9DA915A41CA6301C003723B9 /* UIDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA915A31CA6301C003723B9 /* UIDatePicker.swift */; };
 		9DA915A61CA63046003723B9 /* UIDatePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA915A51CA63046003723B9 /* UIDatePickerTests.swift */; };
 		C72CF3E51CBF188A00E19897 /* RACSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72CF3E41CBF188A00E19897 /* RACSignal.swift */; };
@@ -234,6 +238,7 @@
 		8295FD851B873081007C9000 /* UIControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIControlTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8295FD881B873490007C9000 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIButtonTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8295FD8B1B873748007C9000 /* UIBarButtonItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarButtonItemTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = SOURCE_ROOT; };
 		9DA915A31CA6301C003723B9 /* UIDatePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIDatePicker.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9DA915A51CA63046003723B9 /* UIDatePickerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIDatePickerTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C72CF3E41CBF188A00E19897 /* RACSignal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RACSignal.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -390,6 +395,7 @@
 				D8F097391B17F2BF002E15BA /* Foundation */,
 				D86FFBD31B34B0E2001A89B3 /* UIKit */,
 				D8003E911AFEC3D400D7D3C5 /* Supporting Files */,
+				9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -832,6 +838,7 @@
 				C72CF3E51CBF188A00E19897 /* RACSignal.swift in Sources */,
 				D8A454061BD26A1A00C9E790 /* Property.swift in Sources */,
 				D86FFBDA1B34B3F0001A89B3 /* Action.swift in Sources */,
+				9A5492121D33387D009A8D44 /* Deprecations+Removals.swift in Sources */,
 				D86FFBD11B34AD6F001A89B3 /* Association.swift in Sources */,
 				D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */,
 				D8003EBD1AFED01000D7D3C5 /* Signal.swift in Sources */,
@@ -885,6 +892,7 @@
 				D86FFBD61B34B116001A89B3 /* UIControl.swift in Sources */,
 				D8F0973F1B17F31E002E15BA /* Data.swift in Sources */,
 				D86FFBDD1B34B691001A89B3 /* UIButton.swift in Sources */,
+				9A5492131D33387D009A8D44 /* Deprecations+Removals.swift in Sources */,
 				45CED4711D27C1EB00788BDC /* UIActivityIndicatorView.swift in Sources */,
 				7D0DABAA1CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift in Sources */,
 			);
@@ -930,6 +938,7 @@
 				D8715D9F1C210FF9005F4191 /* Signal.swift in Sources */,
 				C72CF3E81CBF188A00E19897 /* RACSignal.swift in Sources */,
 				D8715DA41C21107F005F4191 /* Data.swift in Sources */,
+				9A5492151D33387D009A8D44 /* Deprecations+Removals.swift in Sources */,
 				D8715D9D1C210FF9005F4191 /* Action.swift in Sources */,
 				D8715DA61C21107F005F4191 /* UserDefaults.swift in Sources */,
 			);
@@ -942,6 +951,7 @@
 				D8715DBB1C2112D1005F4191 /* Property.swift in Sources */,
 				D8715DCA1C211553005F4191 /* UILabel.swift in Sources */,
 				7DCF5B341CC80D78004AEE75 /* UICollectionReusableView.swift in Sources */,
+				9A5492141D33387D009A8D44 /* Deprecations+Removals.swift in Sources */,
 				D8715DCB1C211553005F4191 /* UIImageView.swift in Sources */,
 				C7932E841C4B41E100086F3C /* UITextField.swift in Sources */,
 				7DBD48F41CC8141D0077AD4F /* Reusable.swift in Sources */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -12,9 +12,9 @@
 		45CED4701D27C1E400788BDC /* UIActivityIndicatorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CED46D1D27C1D400788BDC /* UIActivityIndicatorViewTests.swift */; };
 		45CED4711D27C1EB00788BDC /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CED46B1D27BB8700788BDC /* UIActivityIndicatorView.swift */; };
 		45CED4721D27C1EC00788BDC /* UIActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CED46B1D27BB8700788BDC /* UIActivityIndicatorView.swift */; };
+		4A8EDADB1D54D12400A1734C /* UIControl+EnableSendActionsForControlEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DABA91CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift */; };
 		5B7F81E31D0842AD0014B06D /* UISegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1C882D1D0715CE000B888F /* UISegmentedControl.swift */; };
 		5B7F81E41D0842B50014B06D /* UISegmentedControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1C882F1D071639000B888F /* UISegmentedControlTests.swift */; };
-		7D0DABAA1CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DABA91CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift */; };
 		7D2AA99B1CB6EFEB008AB5C9 /* UISwitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2AA99A1CB6EFEB008AB5C9 /* UISwitch.swift */; };
 		7D2AA99D1CB6F275008AB5C9 /* UISwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D2AA99C1CB6F275008AB5C9 /* UISwitchTests.swift */; };
 		7D5FE3081CD4B04E00834675 /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7932E851C4B420A00086F3C /* UITextFieldTests.swift */; };
@@ -882,7 +882,6 @@
 				D8F0973F1B17F31E002E15BA /* NSData.swift in Sources */,
 				D86FFBDD1B34B691001A89B3 /* UIButton.swift in Sources */,
 				45CED4711D27C1EB00788BDC /* UIActivityIndicatorView.swift in Sources */,
-				7D0DABAA1CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -906,6 +905,7 @@
 				C7945F141CC1DFBE00DC9E37 /* UIViewControllerTests.swift in Sources */,
 				7DC3257F1CC6FD1E00746D88 /* UITableViewCellTests.swift in Sources */,
 				9DA915A61CA63046003723B9 /* UIDatePickerTests.swift in Sources */,
+				4A8EDADB1D54D12400A1734C /* UIControl+EnableSendActionsForControlEvents.swift in Sources */,
 				D83457301AFEE45E0070616A /* SignalProducerTests.swift in Sources */,
 				D83457411AFEE6050070616A /* SignalTests.swift in Sources */,
 				8295FD8D1B87374A007C9000 /* UIBarButtonItemTests.swift in Sources */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		9A0501A01D86D76C006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A05019F1D86D765006BBAE8 /* ReactiveSwift.framework */; };
 		9A4375B41D86DBA000F04A59 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0501961D86D713006BBAE8 /* ReactiveSwift.framework */; };
 		9A4375B51D86DBA000F04A59 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; };
+		9A4375B61D86DD1D00F04A59 /* UIControl+EnableSendActionsForControlEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0DABA91CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift */; };
 		9A5492121D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
 		9A5492131D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
 		9A5492141D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
@@ -1015,6 +1016,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A4375B61D86DD1D00F04A59 /* UIControl+EnableSendActionsForControlEvents.swift in Sources */,
 				E6933BEB1CD9C363006F7CE7 /* UIProgressViewTests.swift in Sources */,
 				D8715DE51C211643005F4191 /* UIViewTests.swift in Sources */,
 				7DCF5B371CC80E8E004AEE75 /* UICollectionReusableViewTests.swift in Sources */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -56,8 +56,8 @@
 		CC02C18B1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		CC02C18C1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		D8003E941AFEC3D400D7D3C5 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D8003EB51AFEC6B000D7D3C5 /* Result.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8003EB51AFEC6B000D7D3C5 /* Result.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EB81AFEC7A900D7D3C5 /* SignalProducer.swift */; };
 		D8003EBD1AFED01000D7D3C5 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBC1AFED01000D7D3C5 /* Signal.swift */; };
 		D8003EC21AFED30F00D7D3C5 /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
@@ -71,8 +71,8 @@
 		D83457331AFEE4930070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; };
 		D83457351AFEE4B20070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
 		D83457361AFEE4B20070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
-		D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
-		D834573A1AFEE4BE0070616A /* Result.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
+		D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
+		D834573A1AFEE4BE0070616A /* Result.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
 		D834573C1AFEE57E0070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
 		D834573D1AFEE57E0070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
 		D83457411AFEE6050070616A /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
@@ -125,8 +125,8 @@
 		D8715DE51C211643005F4191 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8289A2E61BD7F7730097FB60 /* UIViewTests.swift */; };
 		D8715DE61C21170C005F4191 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
 		D8715DE71C21170C005F4191 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
-		D8715DE91C211739005F4191 /* ReactiveCocoa.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
-		D8715DEA1C211739005F4191 /* Result.framework in (null) */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
+		D8715DE91C211739005F4191 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8715DC21C211310005F4191 /* ReactiveCocoa.framework */; };
+		D8715DEA1C211739005F4191 /* Result.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D8715DC31C211310005F4191 /* Result.framework */; };
 		D8A454061BD26A1A00C9E790 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A454051BD26A1A00C9E790 /* Property.swift */; };
 		D8A454071BD26A1A00C9E790 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A454051BD26A1A00C9E790 /* Property.swift */; };
 		D8A454091BD2772700C9E790 /* PropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A454081BD2772700C9E790 /* PropertyTests.swift */; };
@@ -140,12 +140,12 @@
 		D8F0973F1B17F31E002E15BA /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F0973A1B17F2F7002E15BA /* NSData.swift */; };
 		D8F097441B17F3C8002E15BA /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097431B17F3C8002E15BA /* NSObject.swift */; };
 		D8F097451B17F3C8002E15BA /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097431B17F3C8002E15BA /* NSObject.swift */; };
+		D8F0974A1B17F5E1002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
+		D8F0974B1B17F5E2002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
 		E6933BEA1CD9C335006F7CE7 /* UIProgressViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */; };
 		E6933BEB1CD9C363006F7CE7 /* UIProgressViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */; };
 		E6933BEC1CD9C37D006F7CE7 /* UIProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */; };
 		E6933BED1CD9C37D006F7CE7 /* UIProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */; };
-		D8F0974A1B17F5E1002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
-		D8F0974B1B17F5E2002E15BA /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F097471B17F5DD002E15BA /* NSObjectTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -173,49 +173,49 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		D8003EB21AFEC6A800D7D3C5 /* (null) */ = {
+		D8003EB21AFEC6A800D7D3C5 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
-				D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in (null) */,
-				D8003EB51AFEC6B000D7D3C5 /* Result.framework in (null) */,
+				D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in CopyFiles */,
+				D8003EB51AFEC6B000D7D3C5 /* Result.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D83457371AFEE4B80070616A /* (null) */ = {
+		D83457371AFEE4B80070616A /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
-				D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in (null) */,
-				D834573A1AFEE4BE0070616A /* Result.framework in (null) */,
+				D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in CopyFiles */,
+				D834573A1AFEE4BE0070616A /* Result.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D8715DE81C21172A005F4191 /* (null) */ = {
+		D8715DE81C21172A005F4191 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
-				D8715DE91C211739005F4191 /* ReactiveCocoa.framework in (null) */,
-				D8715DEA1C211739005F4191 /* Result.framework in (null) */,
+				D8715DE91C211739005F4191 /* ReactiveCocoa.framework in CopyFiles */,
+				D8715DEA1C211739005F4191 /* Result.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4238D5951B4D5950008534C0 /* NSTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NSTextField.swift; path = AppKit/NSTextField.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		45CED46B1D27BB8700788BDC /* UIActivityIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorView.swift; sourceTree = "<group>"; };
 		45CED46D1D27C1D400788BDC /* UIActivityIndicatorViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorViewTests.swift; sourceTree = "<group>"; };
-		4238D5951B4D5950008534C0 /* NSTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NSTextField.swift; path = AppKit/NSTextField.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		5B1C882D1D0715CE000B888F /* UISegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControl.swift; sourceTree = "<group>"; };
-		5B1C882F1D071639000B888F /* UISegmentedControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControlTests.swift; sourceTree = "<group>"; };
 		5173EBC51B625A2600C9B48E /* UIBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarItem.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		5173EBC71B625A6800C9B48E /* UIBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarButtonItem.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		5B1C882D1D0715CE000B888F /* UISegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControl.swift; sourceTree = "<group>"; };
+		5B1C882F1D071639000B888F /* UISegmentedControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISegmentedControlTests.swift; sourceTree = "<group>"; };
 		7D0DABA91CCC381F00B6CD2B /* UIControl+EnableSendActionsForControlEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+EnableSendActionsForControlEvents.swift"; sourceTree = "<group>"; };
 		7D2AA99A1CB6EFEB008AB5C9 /* UISwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UISwitch.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		7D2AA99C1CB6F275008AB5C9 /* UISwitchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UISwitchTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -274,11 +274,11 @@
 		D8A454081BD2772700C9E790 /* PropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PropertyTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F073141B861B3A0047D546 /* UILabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UILabelTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F0973A1B17F2F7002E15BA /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSData.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressView.swift; sourceTree = "<group>"; };
-		E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewTests.swift; sourceTree = "<group>"; };
 		D8F0973C1B17F30D002E15BA /* NSUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSUserDefaults.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F097431B17F3C8002E15BA /* NSObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSObject.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D8F097471B17F5DD002E15BA /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = NSObjectTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		E6933BE61CD9C0B2006F7CE7 /* UIProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressView.swift; sourceTree = "<group>"; };
+		E6933BE81CD9C1F1006F7CE7 /* UIProgressViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -608,7 +608,7 @@
 				D8003E951AFEC3D400D7D3C5 /* Sources */,
 				D8003E961AFEC3D400D7D3C5 /* Frameworks */,
 				D8003E971AFEC3D400D7D3C5 /* Resources */,
-				D8003EB21AFEC6A800D7D3C5 /* (null) */,
+				D8003EB21AFEC6A800D7D3C5 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -645,7 +645,7 @@
 				D834571A1AFEE44E0070616A /* Sources */,
 				D834571B1AFEE44E0070616A /* Frameworks */,
 				D834571C1AFEE44E0070616A /* Resources */,
-				D83457371AFEE4B80070616A /* (null) */,
+				D83457371AFEE4B80070616A /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -700,7 +700,7 @@
 				D8715DCD1C21160A005F4191 /* Sources */,
 				D8715DCE1C21160A005F4191 /* Frameworks */,
 				D8715DCF1C21160A005F4191 /* Resources */,
-				D8715DE81C21172A005F4191 /* (null) */,
+				D8715DE81C21172A005F4191 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -752,7 +752,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex-Mac" */;
+			buildConfigurationList = D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -1421,7 +1421,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex-Mac" */ = {
+		D8003E881AFEC3D400D7D3C5 /* Build configuration list for PBXProject "Rex" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D8003EA21AFEC3D400D7D3C5 /* Debug */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -39,6 +39,17 @@
 		8295FD871B87309F007C9000 /* UIControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD851B873081007C9000 /* UIControlTests.swift */; };
 		8295FD8A1B87352D007C9000 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD881B873490007C9000 /* UIButtonTests.swift */; };
 		8295FD8D1B87374A007C9000 /* UIBarButtonItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8295FD8B1B873748007C9000 /* UIBarButtonItemTests.swift */; };
+		9A0501931D86D6D9006BBAE8 /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9A0501921D86D6D9006BBAE8 /* ReactiveSwift.framework */; };
+		9A0501941D86D6F0006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0501921D86D6D9006BBAE8 /* ReactiveSwift.framework */; };
+		9A0501951D86D6FB006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0501921D86D6D9006BBAE8 /* ReactiveSwift.framework */; };
+		9A0501971D86D713006BBAE8 /* ReactiveSwift.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = 9A0501961D86D713006BBAE8 /* ReactiveSwift.framework */; };
+		9A0501981D86D71D006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0501961D86D713006BBAE8 /* ReactiveSwift.framework */; };
+		9A05019B1D86D737006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A05019A1D86D737006BBAE8 /* ReactiveSwift.framework */; };
+		9A05019D1D86D751006BBAE8 /* ReactiveSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9A05019A1D86D737006BBAE8 /* ReactiveSwift.framework */; };
+		9A05019E1D86D759006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A05019A1D86D737006BBAE8 /* ReactiveSwift.framework */; };
+		9A0501A01D86D76C006BBAE8 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A05019F1D86D765006BBAE8 /* ReactiveSwift.framework */; };
+		9A4375B41D86DBA000F04A59 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A0501961D86D713006BBAE8 /* ReactiveSwift.framework */; };
+		9A4375B51D86DBA000F04A59 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; };
 		9A5492121D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
 		9A5492131D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
 		9A5492141D33387D009A8D44 /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */; };
@@ -60,8 +71,8 @@
 		CC02C18B1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		CC02C18C1CCA704F0025CC04 /* ActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02C1881CCA704C0025CC04 /* ActionTests.swift */; };
 		D8003E941AFEC3D400D7D3C5 /* Rex.h in Headers */ = {isa = PBXBuildFile; fileRef = D8003E931AFEC3D400D7D3C5 /* Rex.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		D8003EB51AFEC6B000D7D3C5 /* Result.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		D8003EB51AFEC6B000D7D3C5 /* Result.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D8003EB91AFEC7A900D7D3C5 /* SignalProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EB81AFEC7A900D7D3C5 /* SignalProducer.swift */; };
 		D8003EBD1AFED01000D7D3C5 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBC1AFED01000D7D3C5 /* Signal.swift */; };
 		D8003EC21AFED30F00D7D3C5 /* SignalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBE1AFED2F800D7D3C5 /* SignalTests.swift */; };
@@ -71,7 +82,6 @@
 		D834572D1AFEE45B0070616A /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EBC1AFED01000D7D3C5 /* Signal.swift */; };
 		D834572E1AFEE45B0070616A /* SignalProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EB81AFEC7A900D7D3C5 /* SignalProducer.swift */; };
 		D83457301AFEE45E0070616A /* SignalProducerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003EC01AFED30100D7D3C5 /* SignalProducerTests.swift */; };
-		D83457321AFEE4930070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */; };
 		D83457331AFEE4930070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EAE1AFEC68A00D7D3C5 /* Result.framework */; };
 		D83457351AFEE4B20070616A /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */; };
 		D83457361AFEE4B20070616A /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */; };
@@ -184,6 +194,7 @@
 			dstSubfolderSpec = 16;
 			files = (
 				D8003EB41AFEC6B000D7D3C5 /* ReactiveCocoa.framework in Copy Files */,
+				9A0501971D86D713006BBAE8 /* ReactiveSwift.framework in Copy Files */,
 				D8003EB51AFEC6B000D7D3C5 /* Result.framework in Copy Files */,
 			);
 			name = "Copy Files";
@@ -196,6 +207,7 @@
 			dstSubfolderSpec = 16;
 			files = (
 				D83457391AFEE4BE0070616A /* ReactiveCocoa.framework in CopyFiles */,
+				9A0501931D86D6D9006BBAE8 /* ReactiveSwift.framework in CopyFiles */,
 				D834573A1AFEE4BE0070616A /* Result.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -206,6 +218,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
+				9A05019D1D86D751006BBAE8 /* ReactiveSwift.framework in CopyFiles */,
 				D8715DE91C211739005F4191 /* ReactiveCocoa.framework in CopyFiles */,
 				D8715DEA1C211739005F4191 /* Result.framework in CopyFiles */,
 			);
@@ -238,6 +251,10 @@
 		8295FD851B873081007C9000 /* UIControlTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIControlTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8295FD881B873490007C9000 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIButtonTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		8295FD8B1B873748007C9000 /* UIBarButtonItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIBarButtonItemTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		9A0501921D86D6D9006BBAE8 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = "<group>"; };
+		9A0501961D86D713006BBAE8 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ReactiveSwift.framework; sourceTree = "<group>"; };
+		9A05019A1D86D737006BBAE8 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = tvOS/ReactiveSwift.framework; sourceTree = "<group>"; };
+		9A05019F1D86D765006BBAE8 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = watchOS/ReactiveSwift.framework; sourceTree = "<group>"; };
 		9A5492111D33387D009A8D44 /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = SOURCE_ROOT; };
 		9DA915A31CA6301C003723B9 /* UIDatePicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIDatePicker.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		9DA915A51CA63046003723B9 /* UIDatePickerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = UIDatePickerTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -261,7 +278,7 @@
 		D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ReactiveCocoa.framework; sourceTree = "<group>"; };
 		D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
 		D86E77A91AFEE646004BF23D /* Rex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D86E77AA1AFEE646004BF23D /* RexTests-Mac.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-Mac.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D86E77AA1AFEE646004BF23D /* RexTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86E77AB1AFEE646004BF23D /* Rex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Rex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86E77AC1AFEE646004BF23D /* RexTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RexTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86FFBD01B34AD6F001A89B3 /* Association.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Association.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -292,8 +309,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D83457321AFEE4930070616A /* ReactiveCocoa.framework in Frameworks */,
 				D83457331AFEE4930070616A /* Result.framework in Frameworks */,
+				9A4375B41D86DBA000F04A59 /* ReactiveSwift.framework in Frameworks */,
+				9A4375B51D86DBA000F04A59 /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -302,6 +320,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8003EC51AFED36F00D7D3C5 /* ReactiveCocoa.framework in Frameworks */,
+				9A0501981D86D71D006BBAE8 /* ReactiveSwift.framework in Frameworks */,
 				D8003EC61AFED36F00D7D3C5 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -310,8 +329,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D83457351AFEE4B20070616A /* ReactiveCocoa.framework in Frameworks */,
 				D83457361AFEE4B20070616A /* Result.framework in Frameworks */,
+				9A0501951D86D6FB006BBAE8 /* ReactiveSwift.framework in Frameworks */,
+				D83457351AFEE4B20070616A /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -320,6 +340,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D834573C1AFEE57E0070616A /* ReactiveCocoa.framework in Frameworks */,
+				9A0501941D86D6F0006BBAE8 /* ReactiveSwift.framework in Frameworks */,
 				D834573D1AFEE57E0070616A /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -328,8 +349,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8715DA91C2110DA005F4191 /* ReactiveCocoa.framework in Frameworks */,
 				D8715DAA1C2110DA005F4191 /* Result.framework in Frameworks */,
+				9A0501A01D86D76C006BBAE8 /* ReactiveSwift.framework in Frameworks */,
+				D8715DA91C2110DA005F4191 /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -337,8 +359,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8715DC41C211310005F4191 /* ReactiveCocoa.framework in Frameworks */,
 				D8715DC51C211310005F4191 /* Result.framework in Frameworks */,
+				9A05019E1D86D759006BBAE8 /* ReactiveSwift.framework in Frameworks */,
+				D8715DC41C211310005F4191 /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -348,6 +371,7 @@
 			files = (
 				D8715DE61C21170C005F4191 /* ReactiveCocoa.framework in Frameworks */,
 				D8715DE71C21170C005F4191 /* Result.framework in Frameworks */,
+				9A05019B1D86D737006BBAE8 /* ReactiveSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -436,7 +460,7 @@
 			isa = PBXGroup;
 			children = (
 				D8003EC71AFEE39000D7D3C5 /* iOS */,
-				D8003EAB1AFEC67700D7D3C5 /* Mac */,
+				D8003EAB1AFEC67700D7D3C5 /* macOS */,
 				D8715DB81C21124B005F4191 /* tvOS */,
 				D8715D9C1C210FA1005F4191 /* watchOS */,
 			);
@@ -444,14 +468,16 @@
 			path = Carthage/Build;
 			sourceTree = "<group>";
 		};
-		D8003EAB1AFEC67700D7D3C5 /* Mac */ = {
+		D8003EAB1AFEC67700D7D3C5 /* macOS */ = {
 			isa = PBXGroup;
 			children = (
 				D86E77A91AFEE646004BF23D /* Rex.framework */,
-				D86E77AA1AFEE646004BF23D /* RexTests-Mac.xctest */,
+				D86E77AA1AFEE646004BF23D /* RexTests-macOS.xctest */,
+				9A0501961D86D713006BBAE8 /* ReactiveSwift.framework */,
 				D8003EAD1AFEC68A00D7D3C5 /* ReactiveCocoa.framework */,
 				D8003EAE1AFEC68A00D7D3C5 /* Result.framework */,
 			);
+			name = macOS;
 			path = Mac;
 			sourceTree = "<group>";
 		};
@@ -460,6 +486,7 @@
 			children = (
 				D86E77AB1AFEE646004BF23D /* Rex.framework */,
 				D86E77AC1AFEE646004BF23D /* RexTests-iOS.xctest */,
+				9A0501921D86D6D9006BBAE8 /* ReactiveSwift.framework */,
 				D8003EC91AFEE3ED00D7D3C5 /* ReactiveCocoa.framework */,
 				D8003ECA1AFEE3ED00D7D3C5 /* Result.framework */,
 			);
@@ -496,6 +523,7 @@
 			children = (
 				D8715D941C210F97005F4191 /* Rex.framework */,
 				D8715DA71C2110DA005F4191 /* ReactiveCocoa.framework */,
+				9A05019F1D86D765006BBAE8 /* ReactiveSwift.framework */,
 				D8715DA81C2110DA005F4191 /* Result.framework */,
 			);
 			name = watchOS;
@@ -506,6 +534,7 @@
 			children = (
 				D8715DB01C21123E005F4191 /* Rex.framework */,
 				D8715DD11C21160A005F4191 /* RexTests-tvOS.xctest */,
+				9A05019A1D86D737006BBAE8 /* ReactiveSwift.framework */,
 				D8715DC21C211310005F4191 /* ReactiveCocoa.framework */,
 				D8715DC31C211310005F4191 /* Result.framework */,
 			);
@@ -593,9 +622,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		D8003E8D1AFEC3D400D7D3C5 /* Rex-Mac */ = {
+		D8003E8D1AFEC3D400D7D3C5 /* Rex-macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D8003EA41AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "Rex-Mac" */;
+			buildConfigurationList = D8003EA41AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "Rex-macOS" */;
 			buildPhases = (
 				D8003E891AFEC3D400D7D3C5 /* Sources */,
 				D8003E8A1AFEC3D400D7D3C5 /* Frameworks */,
@@ -606,14 +635,14 @@
 			);
 			dependencies = (
 			);
-			name = "Rex-Mac";
+			name = "Rex-macOS";
 			productName = Rex;
 			productReference = D86E77A91AFEE646004BF23D /* Rex.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D8003E981AFEC3D400D7D3C5 /* RexTests-Mac */ = {
+		D8003E981AFEC3D400D7D3C5 /* RexTests-macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D8003EA71AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "RexTests-Mac" */;
+			buildConfigurationList = D8003EA71AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "RexTests-macOS" */;
 			buildPhases = (
 				D8003E951AFEC3D400D7D3C5 /* Sources */,
 				D8003E961AFEC3D400D7D3C5 /* Frameworks */,
@@ -625,9 +654,9 @@
 			dependencies = (
 				D8003E9C1AFEC3D400D7D3C5 /* PBXTargetDependency */,
 			);
-			name = "RexTests-Mac";
+			name = "RexTests-macOS";
 			productName = RexTests;
-			productReference = D86E77AA1AFEE646004BF23D /* RexTests-Mac.xctest */;
+			productReference = D86E77AA1AFEE646004BF23D /* RexTests-macOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		D83457131AFEE44E0070616A /* Rex-iOS */ = {
@@ -774,8 +803,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				D8003E8D1AFEC3D400D7D3C5 /* Rex-Mac */,
-				D8003E981AFEC3D400D7D3C5 /* RexTests-Mac */,
+				D8003E8D1AFEC3D400D7D3C5 /* Rex-macOS */,
+				D8003E981AFEC3D400D7D3C5 /* RexTests-macOS */,
 				D83457131AFEE44E0070616A /* Rex-iOS */,
 				D834571D1AFEE44E0070616A /* RexTests-iOS */,
 				D8715DAF1C21123E005F4191 /* Rex-tvOS */,
@@ -1011,7 +1040,7 @@
 /* Begin PBXTargetDependency section */
 		D8003E9C1AFEC3D400D7D3C5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = D8003E8D1AFEC3D400D7D3C5 /* Rex-Mac */;
+			target = D8003E8D1AFEC3D400D7D3C5 /* Rex-macOS */;
 			targetProxy = D8003E9B1AFEC3D400D7D3C5 /* PBXContainerItemProxy */;
 		};
 		D83457211AFEE44E0070616A /* PBXTargetDependency */ = {
@@ -1451,7 +1480,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D8003EA41AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "Rex-Mac" */ = {
+		D8003EA41AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "Rex-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D8003EA51AFEC3D400D7D3C5 /* Debug */,
@@ -1460,7 +1489,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D8003EA71AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "RexTests-Mac" */ = {
+		D8003EA71AFEC3D400D7D3C5 /* Build configuration list for PBXNativeTarget "RexTests-macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D8003EA81AFEC3D400D7D3C5 /* Debug */,

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -724,24 +724,31 @@
 				TargetAttributes = {
 					D8003E8D1AFEC3D400D7D3C5 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D8003E981AFEC3D400D7D3C5 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D83457131AFEE44E0070616A = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D834571D1AFEE44E0070616A = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D8715D931C210F97005F4191 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					D8715DAF1C21123E005F4191 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					D8715DD01C21160A005F4191 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -1048,6 +1055,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1086,6 +1094,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/Rex.xcodeproj/project.pbxproj
+++ b/Rex.xcodeproj/project.pbxproj
@@ -740,9 +740,11 @@
 					};
 					D83457131AFEE44E0070616A = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D834571D1AFEE44E0070616A = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					D8715D931C210F97005F4191 = {
 						CreatedOnToolsVersion = 7.2;
@@ -1221,6 +1223,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1248,6 +1251,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1273,6 +1277,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.neilpa.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1292,6 +1297,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/Rex.xcodeproj/xcshareddata/xcschemes/Rex-Mac.xcscheme
+++ b/Rex.xcodeproj/xcshareddata/xcschemes/Rex-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Rex.xcodeproj/xcshareddata/xcschemes/Rex-Mac.xcscheme
+++ b/Rex.xcodeproj/xcshareddata/xcschemes/Rex-Mac.xcscheme
@@ -16,7 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D8003E8D1AFEC3D400D7D3C5"
                BuildableName = "Rex.framework"
-               BlueprintName = "Rex-Mac"
+               BlueprintName = "Rex-macOS"
                ReferencedContainer = "container:Rex.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -29,8 +29,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D8003E981AFEC3D400D7D3C5"
-               BuildableName = "RexTests-Mac.xctest"
-               BlueprintName = "RexTests-Mac"
+               BuildableName = "RexTests-macOS.xctest"
+               BlueprintName = "RexTests-macOS"
                ReferencedContainer = "container:Rex.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +47,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D8003E981AFEC3D400D7D3C5"
-               BuildableName = "RexTests-Mac.xctest"
-               BlueprintName = "RexTests-Mac"
+               BuildableName = "RexTests-macOS.xctest"
+               BlueprintName = "RexTests-macOS"
                ReferencedContainer = "container:Rex.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +58,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D8003E8D1AFEC3D400D7D3C5"
             BuildableName = "Rex.framework"
-            BlueprintName = "Rex-Mac"
+            BlueprintName = "Rex-macOS"
             ReferencedContainer = "container:Rex.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +80,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D8003E8D1AFEC3D400D7D3C5"
             BuildableName = "Rex.framework"
-            BlueprintName = "Rex-Mac"
+            BlueprintName = "Rex-macOS"
             ReferencedContainer = "container:Rex.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +98,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D8003E8D1AFEC3D400D7D3C5"
             BuildableName = "Rex.framework"
-            BlueprintName = "Rex-Mac"
+            BlueprintName = "Rex-macOS"
             ReferencedContainer = "container:Rex.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Rex.xcodeproj/xcshareddata/xcschemes/Rex-iOS.xcscheme
+++ b/Rex.xcodeproj/xcshareddata/xcschemes/Rex-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Rex.xcodeproj/xcshareddata/xcschemes/Rex-tvOS.xcscheme
+++ b/Rex.xcodeproj/xcshareddata/xcschemes/Rex-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Rex.xcodeproj/xcshareddata/xcschemes/Rex-watchOS.xcscheme
+++ b/Rex.xcodeproj/xcshareddata/xcschemes/Rex-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -12,7 +12,7 @@ import enum Result.NoError
 extension Action {
     /// Creates an always disabled action.
     public static var rex_disabled: Action {
-        return Action(enabledIf: ConstantProperty(false)) { _ in .empty }
+        return Action(enabledIf: Property(value: false)) { _ in .empty }
     }
     
     /// Whether the action execution was started.

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -43,11 +43,11 @@ extension CocoaAction {
 
     /// Creates a producer for the `enabled` state of a CocoaAction.
     public var rex_enabledProducer: SignalProducer<Bool, NoError> {
-        return rex_producerForKeyPath("enabled")
+        return rex_producer(forKeyPath: #keyPath(CocoaAction.isEnabled))
     }
 
     /// Creates a producer for the `executing` state of a CocoaAction.
     public var rex_executingProducer: SignalProducer<Bool, NoError> {
-        return rex_producerForKeyPath("executing")
+        return rex_producer(forKeyPath: #keyPath(CocoaAction.isExecuting))
     }
 }

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -17,7 +17,7 @@ extension Action {
     
     /// Whether the action execution was started.
     public var rex_started: Signal<Void, NoError> {
-        return self.executing.signal
+        return self.isExecuting.signal
             .filterMap { $0 ? () : nil }
     }
 
@@ -25,7 +25,7 @@ extension Action {
     public var rex_completed: Signal<Void, NoError> {
         return events
             .filterMap { event -> Void? in
-                if case .Completed = event {
+                if case .completed = event {
                     return ()
                 } else {
                     return nil

--- a/Source/AppKit/NSTextField.swift
+++ b/Source/AppKit/NSTextField.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import AppKit
 import enum Result.NoError

--- a/Source/AppKit/NSTextField.swift
+++ b/Source/AppKit/NSTextField.swift
@@ -13,8 +13,8 @@ import enum Result.NoError
 extension NSTextField {
     /// Sends the field's string value whenever it changes.
     public var rex_textSignal: SignalProducer<String, NoError> {
-        return NSNotificationCenter.defaultCenter()
-            .rac_notifications(NSControlTextDidChangeNotification, object: self)
+        return NotificationCenter.default
+            .rac_notifications(forName: .NSControlTextDidChange, object: self)
             .map { notification in
                 (notification.object as! NSTextField).stringValue
             }

--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -33,7 +33,7 @@ public func associatedProperty(_ host: AnyObject, keyPath: StaticString) -> Muta
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticString, placeholder: @noescape () -> T) -> MutableProperty<T> {
+public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticString, placeholder: () -> T) -> MutableProperty<T> {
     let setter: (AnyObject, T) -> () = { host, newValue in
         host.setValue(newValue, forKeyPath: String(describing: keyPath))
     }
@@ -48,7 +48,7 @@ public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticS
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty<Host: AnyObject, T>(_ host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T, setter: @escaping (Host, T) -> (), setUp: @noescape (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
+public func associatedProperty<Host: AnyObject, T>(_ host: Host, key: UnsafeRawPointer, initial: (Host) -> T, setter: @escaping (Host, T) -> (), setUp: (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
     return associatedObject(host, key: key) { host in
         let property = MutableProperty(initial(host))
 
@@ -67,7 +67,7 @@ public func associatedProperty<Host: AnyObject, T>(_ host: Host, key: UnsafePoin
 /// On first use attaches the object returned from `initial` to the `host` object using
 /// `key` via `objc_setAssociatedObject`. On subsequent usage, returns said object via
 /// `objc_getAssociatedObject`.
-public func associatedObject<Host: AnyObject, T: AnyObject>(_ host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T) -> T {
+public func associatedObject<Host: AnyObject, T: AnyObject>(_ host: Host, key: UnsafeRawPointer, initial: (Host) -> T) -> T {
     var value = objc_getAssociatedObject(host, key) as? T
     if value == nil {
         value = initial(host)

--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -15,14 +15,14 @@ import ReactiveCocoa
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty(host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
+public func associatedProperty(_ host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
     let initial: (AnyObject) -> String  = { host in
         host.value(forKeyPath: String(keyPath)) as? String ?? ""
     }
     let setter: (AnyObject, String) -> () = { host, newValue in
         host.setValue(newValue, forKeyPath: String(keyPath))
     }
-    return associatedProperty(host: host, key: keyPath.utf8Start, initial: initial, setter: setter)
+    return associatedProperty(host, key: keyPath.utf8Start, initial: initial, setter: setter)
 }
 
 /// Attaches a `MutableProperty` value to the `host` object using KVC to get the initial
@@ -32,11 +32,11 @@ public func associatedProperty(host: AnyObject, keyPath: StaticString) -> Mutabl
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticString, placeholder: @noescape () -> T) -> MutableProperty<T> {
+public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticString, placeholder: @noescape () -> T) -> MutableProperty<T> {
     let setter: (AnyObject, T) -> () = { host, newValue in
         host.setValue(newValue, forKeyPath: String(keyPath))
     }
-    return associatedProperty(host: host, key: keyPath.utf8Start, initial: { host in
+    return associatedProperty(host, key: keyPath.utf8Start, initial: { host in
         host.value(forKeyPath: String(keyPath)) as? T ?? placeholder()
     }, setter: setter)
 }
@@ -47,7 +47,7 @@ public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticStr
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty<Host: AnyObject, T>(host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T, setter: (Host, T) -> (), setUp: @noescape (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
+public func associatedProperty<Host: AnyObject, T>(_ host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T, setter: (Host, T) -> (), setUp: @noescape (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
     return associatedObject(host, key: key) { host in
         let property = MutableProperty(initial(host))
 

--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -15,14 +15,14 @@ import ReactiveCocoa
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty(_ host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
+public func associatedProperty(host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
     let initial: (AnyObject) -> String  = { host in
         host.value(forKeyPath: String(keyPath)) as? String ?? ""
     }
     let setter: (AnyObject, String) -> () = { host, newValue in
         host.setValue(newValue, forKeyPath: String(keyPath))
     }
-    return associatedProperty(host, key: keyPath.utf8Start, initial: initial, setter: setter)
+    return associatedProperty(host: host, key: keyPath.utf8Start, initial: initial, setter: setter)
 }
 
 /// Attaches a `MutableProperty` value to the `host` object using KVC to get the initial
@@ -32,11 +32,11 @@ public func associatedProperty(_ host: AnyObject, keyPath: StaticString) -> Muta
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticString, placeholder: @noescape () -> T) -> MutableProperty<T> {
+public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticString, placeholder: @noescape () -> T) -> MutableProperty<T> {
     let setter: (AnyObject, T) -> () = { host, newValue in
         host.setValue(newValue, forKeyPath: String(keyPath))
     }
-    return associatedProperty(host, key: keyPath.utf8Start, initial: { host in
+    return associatedProperty(host: host, key: keyPath.utf8Start, initial: { host in
         host.value(forKeyPath: String(keyPath)) as? T ?? placeholder()
     }, setter: setter)
 }
@@ -47,7 +47,7 @@ public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticS
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-public func associatedProperty<Host: AnyObject, T>(_ host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T, setter: (Host, T) -> (), setUp: @noescape (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
+public func associatedProperty<Host: AnyObject, T>(host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T, setter: (Host, T) -> (), setUp: @noescape (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
     return associatedObject(host, key: key) { host in
         let property = MutableProperty(initial(host))
 

--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -15,13 +15,12 @@ import ReactiveCocoa
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-@warn_unused_result(message="Did you forget to use the property?")
-public func associatedProperty(host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
-    let initial: AnyObject -> String  = { host in
-        host.valueForKeyPath(keyPath.stringValue) as? String ?? ""
+public func associatedProperty(_ host: AnyObject, keyPath: StaticString) -> MutableProperty<String> {
+    let initial: (AnyObject) -> String  = { host in
+        host.value(forKeyPath: String(keyPath)) as? String ?? ""
     }
     let setter: (AnyObject, String) -> () = { host, newValue in
-        host.setValue(newValue, forKeyPath: keyPath.stringValue)
+        host.setValue(newValue, forKeyPath: String(keyPath))
     }
     return associatedProperty(host, key: keyPath.utf8Start, initial: initial, setter: setter)
 }
@@ -33,13 +32,12 @@ public func associatedProperty(host: AnyObject, keyPath: StaticString) -> Mutabl
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-@warn_unused_result(message="Did you forget to use the property?")
-public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticString, @noescape placeholder: () -> T) -> MutableProperty<T> {
+public func associatedProperty<T: AnyObject>(_ host: AnyObject, keyPath: StaticString, placeholder: @noescape () -> T) -> MutableProperty<T> {
     let setter: (AnyObject, T) -> () = { host, newValue in
-        host.setValue(newValue, forKeyPath: keyPath.stringValue)
+        host.setValue(newValue, forKeyPath: String(keyPath))
     }
     return associatedProperty(host, key: keyPath.utf8Start, initial: { host in
-        host.valueForKeyPath(keyPath.stringValue) as? T ?? placeholder()
+        host.value(forKeyPath: String(keyPath)) as? T ?? placeholder()
     }, setter: setter)
 }
 
@@ -49,8 +47,7 @@ public func associatedProperty<T: AnyObject>(host: AnyObject, keyPath: StaticStr
 ///
 /// This can be used as an alternative to `DynamicProperty` for creating strongly typed
 /// bindings on Cocoa objects.
-@warn_unused_result(message="Did you forget to use the property?")
-public func associatedProperty<Host: AnyObject, T>(host: Host, key: UnsafePointer<()>, @noescape initial: Host -> T, setter: (Host, T) -> (), @noescape setUp: MutableProperty<T> -> () = { _ in }) -> MutableProperty<T> {
+public func associatedProperty<Host: AnyObject, T>(_ host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T, setter: (Host, T) -> (), setUp: @noescape (MutableProperty<T>) -> () = { _ in }) -> MutableProperty<T> {
     return associatedObject(host, key: key) { host in
         let property = MutableProperty(initial(host))
 
@@ -69,7 +66,7 @@ public func associatedProperty<Host: AnyObject, T>(host: Host, key: UnsafePointe
 /// On first use attaches the object returned from `initial` to the `host` object using
 /// `key` via `objc_setAssociatedObject`. On subsequent usage, returns said object via
 /// `objc_getAssociatedObject`.
-public func associatedObject<Host: AnyObject, T: AnyObject>(host: Host, key: UnsafePointer<()>, @noescape initial: Host -> T) -> T {
+public func associatedObject<Host: AnyObject, T: AnyObject>(_ host: Host, key: UnsafePointer<()>, initial: @noescape (Host) -> T) -> T {
     var value = objc_getAssociatedObject(host, key) as? T
     if value == nil {
         value = initial(host)

--- a/Source/Foundation/Association.swift
+++ b/Source/Foundation/Association.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 
 /// Attaches a `MutableProperty` value to the `host` object using KVC to get the initial

--- a/Source/Foundation/Data.swift
+++ b/Source/Foundation/Data.swift
@@ -23,7 +23,7 @@ extension Data {
     }
 }
 
-extension NSData {
+extension Data {
     /// Read the data at the URL, sending the result or an error.
     public static func rex_data(contentsOf url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> {
         return Data.rex_data(contentsOf: url, options: options).map { $0 as NSData }

--- a/Source/Foundation/Data.swift
+++ b/Source/Foundation/Data.swift
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
-import ReactiveCocoa
+import ReactiveSwift
 
 extension Data {
     /// Read the data at the URL, sending the result or an error.

--- a/Source/Foundation/Data.swift
+++ b/Source/Foundation/Data.swift
@@ -10,7 +10,7 @@ import ReactiveCocoa
 
 extension Data {
     /// Read the data at the URL, sending the result or an error.
-    public static func rex_dataWithContentsOfURL(_ url: URL, options: Data.ReadingOptions = []) -> SignalProducer<Data, NSError> {
+    public static func rex_data(contentsOf url: URL, options: Data.ReadingOptions = []) -> SignalProducer<Data, NSError> {
         return SignalProducer<Data, NSError> { observer, disposable in
             do {
                 let data = try Data(contentsOf: url, options: options)
@@ -25,7 +25,7 @@ extension Data {
 
 extension NSData {
     /// Read the data at the URL, sending the result or an error.
-    public static func rex_dataWithContentsOfURL(_ url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> {
+    public static func rex_data(contentsOf url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> {
         return SignalProducer<NSData, NSError> { observer, disposable in
             do {
                 let data = try NSData(contentsOf: url, options: options)

--- a/Source/Foundation/Data.swift
+++ b/Source/Foundation/Data.swift
@@ -26,14 +26,6 @@ extension Data {
 extension NSData {
     /// Read the data at the URL, sending the result or an error.
     public static func rex_data(contentsOf url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> {
-        return SignalProducer<NSData, NSError> { observer, disposable in
-            do {
-                let data = try NSData(contentsOf: url, options: options)
-                observer.sendNext(data)
-                observer.sendCompleted()
-            } catch {
-                observer.sendFailed(error as NSError)
-            }
-        }
+        return Data.rex_data(contentsOf: url, options: options).map { $0 as NSData }
     }
 }

--- a/Source/Foundation/Data.swift
+++ b/Source/Foundation/Data.swift
@@ -1,0 +1,39 @@
+//
+//  Data.swift
+//  Rex
+//
+//  Created by Ilya Laryionau on 10/05/15.
+//  Copyright (c) 2015 Neil Pankey. All rights reserved.
+//
+
+import ReactiveCocoa
+
+extension Data {
+    /// Read the data at the URL, sending the result or an error.
+    public static func rex_dataWithContentsOfURL(_ url: URL, options: Data.ReadingOptions = []) -> SignalProducer<Data, NSError> {
+        return SignalProducer<Data, NSError> { observer, disposable in
+            do {
+                let data = try Data(contentsOf: url, options: options)
+                observer.sendNext(data)
+                observer.sendCompleted()
+            } catch {
+                observer.sendFailed(error as NSError)
+            }
+        }
+    }
+}
+
+extension NSData {
+    /// Read the data at the URL, sending the result or an error.
+    public static func rex_dataWithContentsOfURL(_ url: URL, options: NSData.ReadingOptions = []) -> SignalProducer<NSData, NSError> {
+        return SignalProducer<NSData, NSError> { observer, disposable in
+            do {
+                let data = try NSData(contentsOf: url, options: options)
+                observer.sendNext(data)
+                observer.sendCompleted()
+            } catch {
+                observer.sendFailed(error as NSError)
+            }
+        }
+    }
+}

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -15,16 +15,15 @@ extension NSObject {
     ///
     /// Swift classes deriving `NSObject` must declare properties as `dynamic` for
     /// them to work with KVO. However, this is not recommended practice.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func rex_producerForKeyPath<T>(keyPath: String) -> SignalProducer<T, NoError> {
-        return self.rac_valuesForKeyPath(keyPath, observer: nil)
+    public func rex_producerForKeyPath<T>(_ keyPath: String) -> SignalProducer<T, NoError> {
+        return self.rac_values(forKeyPath: keyPath, observer: nil)
             .toSignalProducer()
             .map { $0 as! T }
             .flatMapError { error in
                 // Errors aren't possible, but the compiler doesn't know that.
                 assertionFailure("Unexpected error from KVO signal: \(error)")
                 return .empty
-        }
+            }
     }
     
     /// Creates a signal that will be triggered when the object

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Foundation/NSObject.swift
+++ b/Source/Foundation/NSObject.swift
@@ -15,7 +15,7 @@ extension NSObject {
     ///
     /// Swift classes deriving `NSObject` must declare properties as `dynamic` for
     /// them to work with KVO. However, this is not recommended practice.
-    public func rex_producerForKeyPath<T>(_ keyPath: String) -> SignalProducer<T, NoError> {
+    public func rex_producer<T>(forKeyPath keyPath: String) -> SignalProducer<T, NoError> {
         return self.rac_values(forKeyPath: keyPath, observer: nil)
             .toSignalProducer()
             .map { $0 as! T }

--- a/Source/Foundation/UserDefaults.swift
+++ b/Source/Foundation/UserDefaults.swift
@@ -14,7 +14,7 @@ extension UserDefaults {
     /// by casting to NSObject and checking for equality. If the values aren't
     /// convertible this will generate events whenever _any_ value in NSUserDefaults
     /// changes.
-    public func rex_valueForKey(_ key: String) -> SignalProducer<AnyObject?, NoError> {
+    public func rex_value(forKey key: String) -> SignalProducer<AnyObject?, NoError> {
         let center = NotificationCenter.default
         let initial = object(forKey: key)
 

--- a/Source/Foundation/UserDefaults.swift
+++ b/Source/Foundation/UserDefaults.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Foundation/UserDefaults.swift
+++ b/Source/Foundation/UserDefaults.swift
@@ -28,7 +28,7 @@ extension UserDefaults {
         return SignalProducer<AnyObject?, NoError>(value: initial)
             .concat(changes)
             .skipRepeats { previous, next in
-                if let previous = previous as? NSObject, next = next as? NSObject {
+                if let previous = previous as? NSObject, let next = next as? NSObject {
                     return previous == next
                 }
                 return false

--- a/Source/Foundation/UserDefaults.swift
+++ b/Source/Foundation/UserDefaults.swift
@@ -9,21 +9,20 @@
 import ReactiveCocoa
 import enum Result.NoError
 
-extension NSUserDefaults {
+extension UserDefaults {
     /// Sends value of `key` whenever it changes. Attempts to filter out repeats
     /// by casting to NSObject and checking for equality. If the values aren't
     /// convertible this will generate events whenever _any_ value in NSUserDefaults
     /// changes.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func rex_valueForKey(key: String) -> SignalProducer<AnyObject?, NoError> {
-        let center = NSNotificationCenter.defaultCenter()
-        let initial = objectForKey(key)
+    public func rex_valueForKey(_ key: String) -> SignalProducer<AnyObject?, NoError> {
+        let center = NotificationCenter.default
+        let initial = object(forKey: key)
 
-        let changes = center.rac_notifications(NSUserDefaultsDidChangeNotification)
+        let changes = center.rac_notifications(forName: UserDefaults.didChangeNotification)
             .map { _ in
                 // The notification doesn't provide what changed so we have to look
                 // it up every time
-                self.objectForKey(key)
+                self.object(forKey: key)
             }
 
         return SignalProducer<AnyObject?, NoError>(value: initial)

--- a/Source/Property.swift
+++ b/Source/Property.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Property.swift
+++ b/Source/Property.swift
@@ -12,33 +12,33 @@ import enum Result.NoError
 extension PropertyProtocol where Value == Bool {
     /// The conjunction of `self` and `other`.
     public func and<P: PropertyProtocol where P.Value == Bool>(_ other: P) -> AndProperty {
-        return AndProperty(terms: [AnyProperty(self), AnyProperty(other)])
+        return AndProperty(terms: [Property(self), Property(other)])
     }
 
     /// The conjunction of `self` and `other`.
-    public func and(_ other: AnyProperty<Bool>) -> AndProperty {
-        return AndProperty(terms: [AnyProperty(self), other])
+    public func and(_ other: Property<Bool>) -> AndProperty {
+        return AndProperty(terms: [Property(self), other])
     }
 
     /// The disjunction of `self` and `other`.
     public func or<P: PropertyProtocol where P.Value == Bool>(_ other: P) -> OrProperty {
-        return OrProperty(terms: [AnyProperty(self), AnyProperty(other)])
+        return OrProperty(terms: [Property(self), Property(other)])
     }
 
     /// The disjunction of `self` and `other`.
-    public func or(_ other: AnyProperty<Bool>) -> OrProperty {
-        return OrProperty(terms: [AnyProperty(self), other])
+    public func or(_ other: Property<Bool>) -> OrProperty {
+        return OrProperty(terms: [Property(self), other])
     }
 
     /// A negated property of `self`.
     public func not() -> NotProperty {
-        return NotProperty(source: AnyProperty(self), invert: true)
+        return NotProperty(source: Property(self), invert: true)
     }
 }
 
 /// Specialized `PropertyType` for the conjuction of a set of boolean properties.
-public struct AndProperty: PropertyProtocol {
-    public let terms: [AnyProperty<Bool>]
+public class AndProperty: PropertyProtocol {
+    public let terms: [Property<Bool>]
 
     public var value: Bool {
         return terms.reduce(true) { $0 && $1.value }
@@ -60,22 +60,22 @@ public struct AndProperty: PropertyProtocol {
 
     /// Creates a new property with an additional conjunctive term.
     public func and<P : PropertyProtocol where P.Value == Bool>(_ other: P) -> AndProperty {
-        return AndProperty(terms: terms + [AnyProperty(other)])
+        return AndProperty(terms: terms + [Property(other)])
     }
 
     /// Creates a new property with an additional conjunctive term.
-    public func and(_ other: AnyProperty<Bool>) -> AndProperty {
+    public func and(_ other: Property<Bool>) -> AndProperty {
         return AndProperty(terms: terms + [other])
     }
 
-    private init(terms: [AnyProperty<Bool>]) {
+    private init(terms: [Property<Bool>]) {
         self.terms = terms
     }
 }
 
 /// Specialized `PropertyType` for the disjunction of a set of boolean properties.
-public struct OrProperty: PropertyProtocol {
-    public let terms: [AnyProperty<Bool>]
+public class OrProperty: PropertyProtocol {
+    public let terms: [Property<Bool>]
     
     public var value: Bool {
         return terms.reduce(false) { $0 || $1.value }
@@ -97,22 +97,22 @@ public struct OrProperty: PropertyProtocol {
 
     /// Creates a new property with an additional disjunctive term.
     public func or<P : PropertyProtocol where P.Value == Bool>(_ other: P) -> OrProperty {
-        return OrProperty(terms: terms + [AnyProperty(other)])
+        return OrProperty(terms: terms + [Property(other)])
     }
 
     /// Creates a new property with an additional disjunctive term.
-    public func or(_ other: AnyProperty<Bool>) -> OrProperty {
+    public func or(_ other: Property<Bool>) -> OrProperty {
         return OrProperty(terms: terms + [other])
     }
 
-    private init(terms: [AnyProperty<Bool>]) {
+    private init(terms: [Property<Bool>]) {
         self.terms = terms
     }
 }
 
 /// Specialized `PropertyType` for the negation of a boolean property.
-public struct NotProperty: PropertyProtocol {
-    private let source: AnyProperty<Bool>
+public class NotProperty: PropertyProtocol {
+    private let source: Property<Bool>
     private let invert: Bool
     
     public var value: Bool {
@@ -132,7 +132,7 @@ public struct NotProperty: PropertyProtocol {
         return NotProperty(source: source, invert: !invert)
     }
 
-    private init(source: AnyProperty<Bool>, invert: Bool) {
+    private init(source: Property<Bool>, invert: Bool) {
         self.source = source
         self.invert = invert
     }

--- a/Source/Property.swift
+++ b/Source/Property.swift
@@ -12,7 +12,7 @@ import enum Result.NoError
 
 extension PropertyProtocol where Value == Bool {
     /// The conjunction of `self` and `other`.
-    public func and<P: PropertyProtocol where P.Value == Bool>(_ other: P) -> AndProperty {
+    public func and<P: PropertyProtocol>(_ other: P) -> AndProperty where P.Value == Bool {
         return AndProperty(terms: [Property(self), Property(other)])
     }
 
@@ -22,7 +22,7 @@ extension PropertyProtocol where Value == Bool {
     }
 
     /// The disjunction of `self` and `other`.
-    public func or<P: PropertyProtocol where P.Value == Bool>(_ other: P) -> OrProperty {
+    public func or<P: PropertyProtocol>(_ other: P) -> OrProperty where P.Value == Bool {
         return OrProperty(terms: [Property(self), Property(other)])
     }
 
@@ -60,7 +60,7 @@ public class AndProperty: PropertyProtocol {
     }
 
     /// Creates a new property with an additional conjunctive term.
-    public func and<P : PropertyProtocol where P.Value == Bool>(_ other: P) -> AndProperty {
+    public func and<P : PropertyProtocol>(_ other: P) -> AndProperty where P.Value == Bool {
         return AndProperty(terms: terms + [Property(other)])
     }
 
@@ -97,7 +97,7 @@ public class OrProperty: PropertyProtocol {
     }
 
     /// Creates a new property with an additional disjunctive term.
-    public func or<P : PropertyProtocol where P.Value == Bool>(_ other: P) -> OrProperty {
+    public func or<P : PropertyProtocol>(_ other: P) -> OrProperty where P.Value == Bool {
         return OrProperty(terms: terms + [Property(other)])
     }
 

--- a/Source/Property.swift
+++ b/Source/Property.swift
@@ -9,40 +9,35 @@
 import ReactiveCocoa
 import enum Result.NoError
 
-extension PropertyType where Value == Bool {
+extension PropertyProtocol where Value == Bool {
     /// The conjunction of `self` and `other`.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func and<P: PropertyType where P.Value == Bool>(other: P) -> AndProperty {
+    public func and<P: PropertyProtocol where P.Value == Bool>(_ other: P) -> AndProperty {
         return AndProperty(terms: [AnyProperty(self), AnyProperty(other)])
     }
 
     /// The conjunction of `self` and `other`.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func and(other: AnyProperty<Bool>) -> AndProperty {
+    public func and(_ other: AnyProperty<Bool>) -> AndProperty {
         return AndProperty(terms: [AnyProperty(self), other])
     }
 
     /// The disjunction of `self` and `other`.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func or<P: PropertyType where P.Value == Bool>(other: P) -> OrProperty {
+    public func or<P: PropertyProtocol where P.Value == Bool>(_ other: P) -> OrProperty {
         return OrProperty(terms: [AnyProperty(self), AnyProperty(other)])
     }
 
     /// The disjunction of `self` and `other`.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func or(other: AnyProperty<Bool>) -> OrProperty {
+    public func or(_ other: AnyProperty<Bool>) -> OrProperty {
         return OrProperty(terms: [AnyProperty(self), other])
     }
 
     /// A negated property of `self`.
-    @warn_unused_result(message="Did you forget to use the property?")
     public func not() -> NotProperty {
         return NotProperty(source: AnyProperty(self), invert: true)
     }
 }
 
 /// Specialized `PropertyType` for the conjuction of a set of boolean properties.
-public struct AndProperty: PropertyType {
+public struct AndProperty: PropertyProtocol {
     public let terms: [AnyProperty<Bool>]
 
     public var value: Bool {
@@ -51,27 +46,25 @@ public struct AndProperty: PropertyType {
 
     public var producer: SignalProducer<Bool, NoError> {
         let producers = terms.map { $0.producer }
-        return combineLatest(producers).map { values in
+        return SignalProducer.combineLatest(producers).map { values in
             return values.reduce(true) { $0 && $1 }
         }
     }
 
     public var signal: Signal<Bool, NoError> {
         let signals = terms.map { $0.signal }
-        return combineLatest(signals).map { values in
+        return Signal.combineLatest(signals).map { values in
             return values.reduce(true) { $0 && $1 }
         }
     }
 
     /// Creates a new property with an additional conjunctive term.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func and<P : PropertyType where P.Value == Bool>(other: P) -> AndProperty {
+    public func and<P : PropertyProtocol where P.Value == Bool>(_ other: P) -> AndProperty {
         return AndProperty(terms: terms + [AnyProperty(other)])
     }
 
     /// Creates a new property with an additional conjunctive term.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func and(other: AnyProperty<Bool>) -> AndProperty {
+    public func and(_ other: AnyProperty<Bool>) -> AndProperty {
         return AndProperty(terms: terms + [other])
     }
 
@@ -81,7 +74,7 @@ public struct AndProperty: PropertyType {
 }
 
 /// Specialized `PropertyType` for the disjunction of a set of boolean properties.
-public struct OrProperty: PropertyType {
+public struct OrProperty: PropertyProtocol {
     public let terms: [AnyProperty<Bool>]
     
     public var value: Bool {
@@ -90,27 +83,25 @@ public struct OrProperty: PropertyType {
     
     public var producer: SignalProducer<Bool, NoError> {
         let producers = terms.map { $0.producer }
-        return combineLatest(producers).map { values in
+        return SignalProducer.combineLatest(producers).map { values in
             return values.reduce(false) { $0 || $1 }
         }
     }
 
     public var signal: Signal<Bool, NoError> {
         let signals = terms.map { $0.signal }
-        return combineLatest(signals).map { values in
+        return Signal.combineLatest(signals).map { values in
             return values.reduce(false) { $0 || $1 }
         }
     }
 
     /// Creates a new property with an additional disjunctive term.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func or<P : PropertyType where P.Value == Bool>(other: P) -> OrProperty {
+    public func or<P : PropertyProtocol where P.Value == Bool>(_ other: P) -> OrProperty {
         return OrProperty(terms: terms + [AnyProperty(other)])
     }
 
     /// Creates a new property with an additional disjunctive term.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func or(other: AnyProperty<Bool>) -> OrProperty {
+    public func or(_ other: AnyProperty<Bool>) -> OrProperty {
         return OrProperty(terms: terms + [other])
     }
 
@@ -120,7 +111,7 @@ public struct OrProperty: PropertyType {
 }
 
 /// Specialized `PropertyType` for the negation of a boolean property.
-public struct NotProperty: PropertyType {
+public struct NotProperty: PropertyProtocol {
     private let source: AnyProperty<Bool>
     private let invert: Bool
     
@@ -137,7 +128,6 @@ public struct NotProperty: PropertyType {
     }
 
     /// A negated property of `self`.
-    @warn_unused_result(message="Did you forget to use the property?")
     public func not() -> NotProperty {
         return NotProperty(source: source, invert: !invert)
     }

--- a/Source/RACSignal.swift
+++ b/Source/RACSignal.swift
@@ -17,7 +17,6 @@ extension RACSignal {
     /// for certain things, like event streams (see `UIControl.signalForControlEvents`)
     /// use this method to be able to expose these inherently hot streams
     /// as `Signal`s.
-    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
     public func rex_toSignal() -> Signal<AnyObject?, NSError> {
         return Signal { observer in
             return self.toSignalProducer().start(observer)
@@ -27,7 +26,6 @@ extension RACSignal {
     /// Converts `self` into a `Signal`, that can be used
     /// with the `takeUntil` operator, or as an "activation" signal.
     /// (e.g. a button)
-    @warn_unused_result(message="Did you forget to call `observe` on the signal?")
     public final func rex_toTriggerSignal() -> Signal<(), NoError> {
         return self
             .rex_toSignal()

--- a/Source/RACSignal.swift
+++ b/Source/RACSignal.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Reusable.swift
+++ b/Source/Reusable.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/Signal.swift
+++ b/Source/Signal.swift
@@ -82,7 +82,7 @@ extension SignalProtocol {
     ///
     /// This operator could be used to coalesce multiple notifications in a short time
     /// frame by only showing the first one.
-    public func muteFor(_ interval: TimeInterval, clock: DateSchedulerProtocol) -> Signal<Value, Error> {
+    public func mute(for interval: TimeInterval, clock: DateSchedulerProtocol) -> Signal<Value, Error> {
         precondition(interval > 0)
 
         var expires = clock.currentDate

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import enum Result.NoError
 

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -9,28 +9,27 @@
 import ReactiveCocoa
 import enum Result.NoError
 
-extension SignalProducerType {
+extension SignalProducerProtocol {
 
     /// Buckets each received value into a group based on the key returned
     /// from `grouping`. Termination events on the original signal are
     /// also forwarded to each producer group.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func groupBy<Key: Hashable>(grouping: Value -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
+    public func group<Key: Hashable>(by grouping: (Value) -> Key) -> SignalProducer<(Key, SignalProducer<Value, Error>), Error> {
         return SignalProducer<(Key, SignalProducer<Value, Error>), Error> { observer, disposable in
             var groups: [Key: Signal<Value, Error>.Observer] = [:]
 
-            let lock = NSRecursiveLock()
+            let lock = RecursiveLock()
             lock.name = "me.neilpa.rex.groupBy"
 
             self.start { event in
                 switch event {
-                case let .Next(value):
+                case let .next(value):
                     let key = grouping(value)
 
                     lock.lock()
                     var group = groups[key]
                     if group == nil {
-                        let (producer, innerObserver) = SignalProducer<Value, Error>.buffer(Int.max)
+                        let (producer, innerObserver) = SignalProducer<Value, Error>.bufferingProducer(upTo: Int.max)
                         observer.sendNext(key, producer)
 
                         groups[key] = innerObserver
@@ -40,15 +39,15 @@ extension SignalProducerType {
                     
                     group!.sendNext(value)
 
-                case let .Failed(error):
+                case let .failed(error):
                     observer.sendFailed(error)
                     groups.values.forEach { $0.sendFailed(error) }
 
-                case .Completed:
+                case .completed:
                     observer.sendCompleted()
                     groups.values.forEach { $0.sendCompleted() }
 
-                case .Interrupted:
+                case .interrupted:
                     observer.sendInterrupted()
                     groups.values.forEach { $0.sendInterrupted() }
                 }
@@ -58,15 +57,13 @@ extension SignalProducerType {
 
     /// Applies `transform` to values from self with non-`nil` results unwrapped and
     /// forwared on the returned producer.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func filterMap<U>(transform: Value -> U?) -> SignalProducer<U, Error> {
+    public func filterMap<U>(_ transform: (Value) -> U?) -> SignalProducer<U, Error> {
         return lift { $0.filterMap(transform) }
     }
 
     /// Returns a producer that drops `Error` sending `replacement` terminal event
     /// instead, defaulting to `Completed`.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func ignoreError(replacement replacement: Event<Value, NoError> = .Completed) -> SignalProducer<Value, NoError> {
+    public func ignoreError(replacement: Event<Value, NoError> = .completed) -> SignalProducer<Value, NoError> {
         precondition(replacement.isTerminating)
         return lift { $0.ignoreError(replacement: replacement) }
     }
@@ -76,9 +73,8 @@ extension SignalProducerType {
     ///
     /// If the interval is 0, the timeout will be scheduled immediately. The producer
     /// must complete synchronously (or on a faster scheduler) to avoid the timeout.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func timeoutAfter(interval: NSTimeInterval, withEvent event: Event<Value, Error>, onScheduler scheduler: DateSchedulerType) -> SignalProducer<Value, Error> {
-        return lift { $0.timeoutAfter(interval, withEvent: event, onScheduler: scheduler) }
+    public func timeout(after interval: TimeInterval, with event: Event<Value, Error>, on scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
+        return lift { $0.timeout(after: interval, with: event, on: scheduler) }
     }
 
     /// Forwards a value and then mutes the producer by dropping all subsequent values
@@ -88,22 +84,19 @@ extension SignalProducerType {
     ///
     /// This operator could be used to coalesce multiple notifications in a short time
     /// frame by only showing the first one.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func muteFor(interval: NSTimeInterval, clock: DateSchedulerType) -> SignalProducer<Value, Error> {
+    public func mute(for interval: TimeInterval, clock: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
         return lift { $0.muteFor(interval, clock: clock) }
     }
 
     /// Delays the start of the producer by `interval` on the provided scheduler.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func deferred(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType) -> SignalProducer<Value, Error> {
+    public func `defer`(by interval: TimeInterval, on scheduler: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
         return SignalProducer.empty
-            .delay(interval, onScheduler: scheduler)
+            .delay(interval, on: scheduler)
             .concat(self.producer)
     }
 
     /// Delays retrying on failure by `interval` up to `count` attempts.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func deferredRetry(interval: NSTimeInterval, onScheduler scheduler: DateSchedulerType, count: Int = .max) -> SignalProducer<Value, Error> {
+    public func deferredRetry(interval: TimeInterval, on scheduler: DateSchedulerProtocol, count: Int = .max) -> SignalProducer<Value, Error> {
         precondition(count >= 0)
 
         if count == 0 {
@@ -115,20 +108,143 @@ extension SignalProducerType {
                 // The final attempt shouldn't defer the error if it fails
                 var producer = SignalProducer<Value, Error>(error: error)
                 if retries > 0 {
-                    producer = producer.deferred(interval, onScheduler: scheduler)
+                    producer = producer.defer(by: interval, on: scheduler)
                 }
 
                 retries -= 1
                 return producer
             }
-            .retry(count)
+            .retry(upTo: count)
     }
 }
 
-extension SignalProducerType where Value: SequenceType {
+extension SignalProducerProtocol where Value: Sequence {
     /// Returns a producer that flattens sequences of elements. The inverse of `collect`.
-    @warn_unused_result(message="Did you forget to call `start` on the producer?")
-    public func uncollect() -> SignalProducer<Value.Generator.Element, Error> {
+    public func uncollect() -> SignalProducer<Value.Iterator.Element, Error> {
         return lift { $0.uncollect() }
+    }
+}
+
+/// Temporary replacement of `buffer(upTo:)`.
+/// https://github.com/ReactiveCocoa/ReactiveCocoa/blob/RAC5-swift3/ReactiveCocoa/Swift/SignalProducer.swift
+
+extension SignalProducer {
+    private static func bufferingProducer(upTo capacity: Int) -> (SignalProducer, Signal<Value, Error>.Observer) {
+        precondition(capacity >= 0, "Invalid capacity: \(capacity)")
+
+        // Used as an atomic variable so we can remove observers without needing
+        // to run on a serial queue.
+        let state: Atomic<BufferState<Value, Error>> = Atomic(BufferState())
+
+        let producer = self.init { observer, disposable in
+            // Assigned to when replay() is invoked synchronously below.
+            var token: RemovalToken?
+
+            let replayBuffer = ReplayBuffer<Value>()
+            var replayValues: [Value] = []
+            var replayToken: RemovalToken?
+            var next = state.modify { state in
+                replayValues = state.values
+                if replayValues.isEmpty {
+                    token = state.observers?.insert(observer)
+                } else {
+                    replayToken = state.replayBuffers.insert(replayBuffer)
+                }
+            }
+
+            while !replayValues.isEmpty {
+                replayValues.forEach(observer.sendNext)
+
+                next = state.modify { state in
+                    replayValues = replayBuffer.values
+                    replayBuffer.values = []
+                    if replayValues.isEmpty {
+                        if let replayToken = replayToken {
+                            state.replayBuffers.remove(using: replayToken)
+                        }
+                        token = state.observers?.insert(observer)
+                    }
+                }
+            }
+
+            if let terminationEvent = next.terminationEvent {
+                observer.action(terminationEvent)
+            }
+
+            if let token = token {
+                disposable += {
+                    state.modify { state in
+                        state.observers?.remove(using: token)
+                    }
+                }
+            }
+        }
+
+        let bufferingObserver: Signal<Value, Error>.Observer = Observer { event in
+            let originalState = state.modify { state in
+                if let value = event.value {
+                    state.add(value, upTo: capacity)
+                } else {
+                    // Disconnect all observers and prevent future
+                    // attachments.
+                    state.terminationEvent = event
+                    state.observers = nil
+                }
+            }
+
+            originalState.observers?.forEach { $0.action(event) }
+        }
+
+        return (producer, bufferingObserver)
+    }
+}
+
+/// A uniquely identifying token for Observers that are replaying values in
+/// BufferState.
+private final class ReplayBuffer<Value> {
+    private var values: [Value] = []
+}
+
+private struct BufferState<Value, Error: ErrorProtocol> {
+    /// All values in the buffer.
+    var values: [Value] = []
+
+    /// Any terminating event sent to the buffer.
+    ///
+    /// This will be nil if termination has not occurred.
+    var terminationEvent: Event<Value, Error>?
+    
+    /// The observers currently attached to the buffered producer, or nil if the
+    /// producer was terminated.
+    var observers: Bag<Signal<Value, Error>.Observer>? = Bag()
+    
+    /// The set of unused replay token identifiers.
+    var replayBuffers: Bag<ReplayBuffer<Value>> = Bag()
+    
+    /// Appends a new value to the buffer, trimming it down to the given capacity
+    /// if necessary.
+    mutating func add(_ value: Value, upTo capacity: Int) {
+        precondition(capacity >= 0)
+        
+        for buffer in replayBuffers {
+            buffer.values.append(value)
+        }
+        
+        if capacity == 0 {
+            values = []
+            return
+        }
+        
+        if capacity == 1 {
+            values = [ value ]
+            return
+        }
+        
+        values.append(value)
+        
+        let overflow = values.count - capacity
+        if overflow > 0 {
+            values.removeSubrange(0..<overflow)
+        }
     }
 }

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -18,7 +18,7 @@ extension SignalProducerProtocol {
         return SignalProducer<(Key, SignalProducer<Value, Error>), Error> { observer, disposable in
             var groups: [Key: Signal<Value, Error>.Observer] = [:]
 
-            let lock = RecursiveLock()
+            let lock = NSRecursiveLock()
             lock.name = "me.neilpa.rex.groupBy"
 
             self.start { event in
@@ -96,7 +96,7 @@ extension SignalProducerProtocol {
     }
 
     /// Delays retrying on failure by `interval` up to `count` attempts.
-    public func deferredRetry(interval: TimeInterval, on scheduler: DateSchedulerProtocol, count: Int = .max) -> SignalProducer<Value, Error> {
+    public func deferredRetry(_ interval: TimeInterval, on scheduler: DateSchedulerProtocol, count: Int = .max) -> SignalProducer<Value, Error> {
         precondition(count >= 0)
 
         if count == 0 {
@@ -205,25 +205,25 @@ private final class ReplayBuffer<Value> {
     private var values: [Value] = []
 }
 
-private struct BufferState<Value, Error: ErrorProtocol> {
+private struct BufferState<V, E: Error> {
     /// All values in the buffer.
-    var values: [Value] = []
+    var values: [V] = []
 
     /// Any terminating event sent to the buffer.
     ///
     /// This will be nil if termination has not occurred.
-    var terminationEvent: Event<Value, Error>?
+    var terminationEvent: Event<V, E>?
     
     /// The observers currently attached to the buffered producer, or nil if the
     /// producer was terminated.
-    var observers: Bag<Signal<Value, Error>.Observer>? = Bag()
+    var observers: Bag<Signal<V, E>.Observer>? = Bag()
     
     /// The set of unused replay token identifiers.
-    var replayBuffers: Bag<ReplayBuffer<Value>> = Bag()
+    var replayBuffers: Bag<ReplayBuffer<V>> = Bag()
     
     /// Appends a new value to the buffer, trimming it down to the given capacity
     /// if necessary.
-    mutating func add(_ value: Value, upTo capacity: Int) {
+    mutating func add(_ value: V, upTo capacity: Int) {
         precondition(capacity >= 0)
         
         for buffer in replayBuffers {

--- a/Source/SignalProducer.swift
+++ b/Source/SignalProducer.swift
@@ -85,7 +85,7 @@ extension SignalProducerProtocol {
     /// This operator could be used to coalesce multiple notifications in a short time
     /// frame by only showing the first one.
     public func mute(for interval: TimeInterval, clock: DateSchedulerProtocol) -> SignalProducer<Value, Error> {
-        return lift { $0.muteFor(interval, clock: clock) }
+        return lift { $0.mute(for: interval, clock: clock) }
     }
 
     /// Delays the start of the producer by `interval` on the provided scheduler.

--- a/Source/UIKit/UIActivityIndicatorView.swift
+++ b/Source/UIKit/UIActivityIndicatorView.swift
@@ -15,7 +15,7 @@ extension UIActivityIndicatorView {
     /// Setting a new value to the property would call `startAnimating()` or
     /// `stopAnimating()` depending on the value.
     public var rex_animating: MutableProperty<Bool> {
-        return associatedProperty(self, key: &animatingKey, initial: { $0.isAnimating() }, setter: { host, animating in
+        return associatedProperty(host: self, key: &animatingKey, initial: { $0.isAnimating() }, setter: { host, animating in
             if animating {
                 host.startAnimating()
             } else {
@@ -23,7 +23,6 @@ extension UIActivityIndicatorView {
             }
         })
     }
-
 }
 
 private var animatingKey: UInt8 = 0

--- a/Source/UIKit/UIActivityIndicatorView.swift
+++ b/Source/UIKit/UIActivityIndicatorView.swift
@@ -14,15 +14,15 @@ extension UIActivityIndicatorView {
     /// Wraps an indicator's `isAnimating()` state in a bindable property.
     /// Setting a new value to the property would call `startAnimating()` or
     /// `stopAnimating()` depending on the value.
-    public var rex_animating: MutableProperty<Bool> {
-        return associatedProperty(host: self, key: &animatingKey, initial: { $0.isAnimating() }, setter: { host, animating in
-            if animating {
-                host.startAnimating()
-            } else {
-                host.stopAnimating()
-            }
-        })
-    }
+//    public var rex_animating: MutableProperty<Bool> {
+//        return associatedProperty(self, key: &animatingKey, initial: { $0.isAnimating() }, setter: { host, animating in
+//            if animating {
+//                host.startAnimating()
+//            } else {
+//                host.stopAnimating()
+//            }
+//        })
+//    }
 }
 
 private var animatingKey: UInt8 = 0

--- a/Source/UIKit/UIActivityIndicatorView.swift
+++ b/Source/UIKit/UIActivityIndicatorView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UIActivityIndicatorView.swift
+++ b/Source/UIKit/UIActivityIndicatorView.swift
@@ -14,15 +14,15 @@ extension UIActivityIndicatorView {
     /// Wraps an indicator's `isAnimating()` state in a bindable property.
     /// Setting a new value to the property would call `startAnimating()` or
     /// `stopAnimating()` depending on the value.
-//    public var rex_animating: MutableProperty<Bool> {
-//        return associatedProperty(self, key: &animatingKey, initial: { $0.isAnimating() }, setter: { host, animating in
-//            if animating {
-//                host.startAnimating()
-//            } else {
-//                host.stopAnimating()
-//            }
-//        })
-//    }
+    public var rex_animating: MutableProperty<Bool> {
+        return associatedProperty(self, key: &animatingKey, initial: { $0.isAnimating }, setter: { host, animating in
+            if animating {
+                host.startAnimating()
+            } else {
+                host.stopAnimating()
+            }
+        })
+    }
 }
 
 private var animatingKey: UInt8 = 0

--- a/Source/UIKit/UIBarButtonItem.swift
+++ b/Source/UIKit/UIBarButtonItem.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UIBarButtonItem.swift
+++ b/Source/UIKit/UIBarButtonItem.swift
@@ -25,7 +25,7 @@ extension UIBarButtonItem {
                     host?.action = CocoaAction.selector
                 }
 
-            host.rex_enabled <~ property.producer.flatMap(.Latest) { $0.rex_enabledProducer }
+            host.rex_enabled <~ property.producer.flatMap(.latest) { $0.rex_enabledProducer }
 
             return property
         }

--- a/Source/UIKit/UIBarItem.swift
+++ b/Source/UIKit/UIBarItem.swift
@@ -12,7 +12,7 @@ import UIKit
 extension UIBarItem {
     /// Wraps a UIBarItem's `enabled` state in a bindable property.
     public var rex_enabled: MutableProperty<Bool> {
-        return associatedProperty(self, key: &enabledKey, initial: { $0.enabled }, setter: { $0.enabled = $1 })
+        return associatedProperty(self, key: &enabledKey, initial: { $0.isEnabled }, setter: { $0.isEnabled = $1 })
     }
 }
 

--- a/Source/UIKit/UIBarItem.swift
+++ b/Source/UIKit/UIBarItem.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -20,13 +20,13 @@ extension UIButton {
             let property = MutableProperty(initial)
 
             property.producer
-                .combinePrevious(initial)
+                .combinePrevious(initial: initial)
                 .startWithNext { [weak host] previous, next in
-                    host?.removeTarget(previous, action: CocoaAction.selector, forControlEvents: .TouchUpInside)
-                    host?.addTarget(next, action: CocoaAction.selector, forControlEvents: .TouchUpInside)
+                    host?.removeTarget(previous, action: CocoaAction.selector, for: .touchUpInside)
+                    host?.addTarget(next, action: CocoaAction.selector, for: .touchUpInside)
                 }
 
-            host.rex_enabled <~ property.producer.flatMap(.Latest) { $0.rex_enabledProducer }
+            host.rex_enabled <~ property.producer.flatMap(.latest) { $0.rex_enabledProducer }
 
             return property
         }
@@ -35,7 +35,7 @@ extension UIButton {
     /// Wraps a button's `title` text in a bindable property. Note that this only applies
     /// to `UIControlState.Normal`.
     public var rex_title: MutableProperty<String> {
-        return associatedProperty(self, key: &titleKey, initial: { $0.titleForState(.Normal) ?? "" }, setter: { $0.setTitle($1, forState: .Normal) })
+        return associatedProperty(self, key: &titleKey, initial: { $0.title(for: .normal) ?? "" }, setter: { $0.setTitle($1, for: .normal) })
     }
 }
 

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UIButton.swift
+++ b/Source/UIKit/UIButton.swift
@@ -20,7 +20,7 @@ extension UIButton {
             let property = MutableProperty(initial)
 
             property.producer
-                .combinePrevious(initial: initial)
+                .combinePrevious(initial)
                 .startWithNext { [weak host] previous, next in
                     host?.removeTarget(previous, action: CocoaAction.selector, for: .touchUpInside)
                     host?.addTarget(next, action: CocoaAction.selector, for: .touchUpInside)

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -14,9 +14,8 @@ extension UIControl {
 
 #if os(iOS)
     /// Creates a producer for the sender whenever a specified control event is triggered.
-    @warn_unused_result(message="Did you forget to use the property?")
-    public func rex_controlEvents(events: UIControlEvents) -> SignalProducer<UIControl?, NoError> {
-        return rac_signalForControlEvents(events)
+    public func rex_controlEvents(_ events: UIControlEvents) -> SignalProducer<UIControl?, NoError> {
+        return rac_signal(for: events)
             .toSignalProducer()
             .map { $0 as? UIControl }
             .flatMapError { _ in SignalProducer(value: nil) }
@@ -27,11 +26,10 @@ extension UIControl {
     /// This property uses `UIControlEvents.ValueChanged` and `UIControlEvents.EditingChanged` 
     /// events to detect changes and keep the value up-to-date.
     //
-    @warn_unused_result(message="Did you forget to use the property?")
-    class func rex_value<Host: UIControl, T>(host: Host, getter: Host -> T, setter: (Host, T) -> ()) -> MutableProperty<T> {
+    class func rex_value<Host: UIControl, T>(_ host: Host, getter: (Host) -> T, setter: (Host, T) -> ()) -> MutableProperty<T> {
         return associatedProperty(host, key: &valueChangedKey, initial: getter, setter: setter) { property in
             property <~
-                host.rex_controlEvents([.ValueChanged, .EditingChanged])
+                host.rex_controlEvents([.valueChanged, .editingChanged])
                     .filterMap { $0 as? Host }
                     .filterMap(getter)
         }
@@ -40,17 +38,17 @@ extension UIControl {
 
     /// Wraps a control's `enabled` state in a bindable property.
     public var rex_enabled: MutableProperty<Bool> {
-        return associatedProperty(self, key: &enabledKey, initial: { $0.enabled }, setter: { $0.enabled = $1 })
+        return associatedProperty(self, key: &enabledKey, initial: { $0.isEnabled }, setter: { $0.isEnabled = $1 })
     }
     
     /// Wraps a control's `selected` state in a bindable property.
     public var rex_selected: MutableProperty<Bool> {
-        return associatedProperty(self, key: &selectedKey, initial: { $0.selected }, setter: { $0.selected = $1 })
+        return associatedProperty(self, key: &selectedKey, initial: { $0.isSelected }, setter: { $0.isSelected = $1 })
     }
     
     /// Wraps a control's `highlighted` state in a bindable property.
     public var rex_highlighted: MutableProperty<Bool> {
-        return associatedProperty(self, key: &highlightedKey, initial: { $0.highlighted }, setter: { $0.highlighted = $1 })
+        return associatedProperty(self, key: &highlightedKey, initial: { $0.isHighlighted }, setter: { $0.isHighlighted = $1 })
     }
 }
 

--- a/Source/UIKit/UIControl.swift
+++ b/Source/UIKit/UIControl.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import enum Result.NoError

--- a/Source/UIKit/UIDatePicker.swift
+++ b/Source/UIKit/UIDatePicker.swift
@@ -12,7 +12,7 @@ import UIKit
 extension UIDatePicker {
 
     // Wraps a datePicker's `date` value in a bindable property.
-    public var rex_date: MutableProperty<NSDate> {
+    public var rex_date: MutableProperty<Date> {
         return UIControl.rex_value(self, getter: { $0.date }, setter: { $0.date = $1 })
     }
 }

--- a/Source/UIKit/UIDatePicker.swift
+++ b/Source/UIKit/UIDatePicker.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UIImageView.swift
+++ b/Source/UIKit/UIImageView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -16,7 +16,7 @@ extension UILabel {
     }
     
     /// Wraps a label's `attributedText` value in a bindable property.
-    public var rex_attributedText: MutableProperty<NSAttributedString?> {
+    public var rex_attributedText: MutableProperty<AttributedString?> {
         return associatedProperty(self, key: &attributedTextKey, initial: { $0.attributedText }, setter: { $0.attributedText = $1 })
     }
 

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UILabel.swift
+++ b/Source/UIKit/UILabel.swift
@@ -16,7 +16,7 @@ extension UILabel {
     }
     
     /// Wraps a label's `attributedText` value in a bindable property.
-    public var rex_attributedText: MutableProperty<AttributedString?> {
+    public var rex_attributedText: MutableProperty<NSAttributedString?> {
         return associatedProperty(self, key: &attributedTextKey, initial: { $0.attributedText }, setter: { $0.attributedText = $1 })
     }
 

--- a/Source/UIKit/UIProgressView.swift
+++ b/Source/UIKit/UIProgressView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UISegmentedControl.swift
+++ b/Source/UIKit/UISegmentedControl.swift
@@ -13,7 +13,7 @@ extension UISegmentedControl {
     /// Wraps a segmentedControls `selectedSegmentIndex` state in a bindable property.
     public var rex_selectedSegmentIndex: MutableProperty<Int> {
         let property = associatedProperty(self, key: &selectedSegmentIndexKey, initial: { $0.selectedSegmentIndex }, setter: { $0.selectedSegmentIndex = $1 })
-        property <~ rex_controlEvents(.ValueChanged)
+        property <~ rex_controlEvents(.valueChanged)
             .filterMap { ($0 as? UISegmentedControl)?.selectedSegmentIndex }
         return property
     }

--- a/Source/UIKit/UISegmentedControl.swift
+++ b/Source/UIKit/UISegmentedControl.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UISwitch.swift
+++ b/Source/UIKit/UISwitch.swift
@@ -13,6 +13,6 @@ extension UISwitch {
 
     /// Wraps a switch's `on` value in a bindable property.
     public var rex_on: MutableProperty<Bool> {
-        return UIControl.rex_value(self, getter: { $0.on }, setter: { $0.on = $1 })
+        return UIControl.rex_value(self, getter: { $0.isOn }, setter: { $0.isOn = $1 })
     }
 }

--- a/Source/UIKit/UISwitch.swift
+++ b/Source/UIKit/UISwitch.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UITextField.swift
+++ b/Source/UIKit/UITextField.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UITextField.swift
+++ b/Source/UIKit/UITextField.swift
@@ -20,8 +20,8 @@ extension UITextField {
 #else
         return associatedProperty(self, key: &textKey, initial: getter, setter: setter) { property in
             property <~
-                NSNotificationCenter.defaultCenter()
-                    .rac_notifications(UITextFieldTextDidChangeNotification, object: self)
+                NotificationCenter.default
+                    .rac_notifications(forName: .UITextFieldTextDidChange, object: self)
                     .filterMap  { ($0.object as? UITextField)?.text }
             }
 #endif

--- a/Source/UIKit/UITextField.swift
+++ b/Source/UIKit/UITextField.swift
@@ -13,7 +13,7 @@ extension UITextField {
     
     /// Wraps a textField's `text` value in a bindable property.
     public var rex_text: MutableProperty<String?> {
-        let getter: UITextField -> String? = { $0.text }
+        let getter: (UITextField) -> String? = { $0.text }
         let setter: (UITextField, String?) -> () = { $0.text = $1 }
 #if os(iOS)
         return UIControl.rex_value(self, getter: getter, setter: setter)

--- a/Source/UIKit/UITextView.swift
+++ b/Source/UIKit/UITextView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import enum Result.NoError

--- a/Source/UIKit/UITextView.swift
+++ b/Source/UIKit/UITextView.swift
@@ -14,8 +14,8 @@ extension UITextView {
     
     /// Sends the textView's string value whenever it changes.
     public var rex_text: SignalProducer<String, NoError> {
-        return NSNotificationCenter.defaultCenter()
-            .rac_notifications(UITextViewTextDidChangeNotification, object: self)
+        return NotificationCenter.default
+            .rac_notifications(forName: .UITextViewTextDidChange, object: self)
             .filterMap  { ($0.object as? UITextView)?.text }
     }
 }

--- a/Source/UIKit/UIView.swift
+++ b/Source/UIKit/UIView.swift
@@ -17,13 +17,13 @@ extension UIView {
     
     /// Wraps a view's `hidden` state in a bindable property.
     public var rex_hidden: MutableProperty<Bool> {
-        return associatedProperty(self, key: &hiddenKey, initial: { $0.hidden }, setter: { $0.hidden = $1 })
+        return associatedProperty(self, key: &hiddenKey, initial: { $0.isHidden }, setter: { $0.isHidden = $1 })
     }
     
-        
+
     /// Wraps a view's `userInteractionEnabled` state in a bindable property.
     public var rex_userInteractionEnabled: MutableProperty<Bool> {
-        return associatedProperty(self, key: &userInteractionEnabledKey, initial: { $0.userInteractionEnabled }, setter: { $0.userInteractionEnabled = $1 })
+        return associatedProperty(self, key: &userInteractionEnabledKey, initial: { $0.isUserInteractionEnabled }, setter: { $0.isUserInteractionEnabled = $1 })
     }
 }
 

--- a/Source/UIKit/UIView.swift
+++ b/Source/UIKit/UIView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import Result
 import ReactiveCocoa
 import UIKit

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -35,7 +35,7 @@ extension UIViewController {
         return triggerForSelector(#selector(UIViewController.viewWillAppear(_:)))
     }
     
-    private func triggerForSelector(_ selector: Selector) -> Signal<(), NoError>  {
+    private func trigger(for selector: Selector) -> Signal<(), NoError>  {
         return self
             .rac_signal(for: selector)
             .rex_toTriggerSignal()

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -35,13 +35,13 @@ extension UIViewController {
         return triggerForSelector(#selector(UIViewController.viewWillAppear(_:)))
     }
     
-    private func triggerForSelector(selector: Selector) -> Signal<(), NoError>  {
+    private func triggerForSelector(_ selector: Selector) -> Signal<(), NoError>  {
         return self
-            .rac_signalForSelector(selector)
+            .rac_signal(for: selector)
             .rex_toTriggerSignal()
     }
     
-    public typealias DismissingCompletion = (Void -> Void)?
+    public typealias DismissingCompletion = ((Void) -> Void)?
     public typealias DismissingInformation = (animated: Bool, completion: DismissingCompletion)?
     
     /// Wraps a viewController's `dismissViewControllerAnimated` function in a bindable property.
@@ -56,16 +56,16 @@ extension UIViewController {
     /// or `viewController.dismissViewControllerAnimated(true, completion: nil)`
     public var rex_dismissAnimated: MutableProperty<DismissingInformation> {
         
-        let initial: UIViewController -> DismissingInformation = { _ in nil }
+        let initial: (UIViewController) -> DismissingInformation = { _ in nil }
         let setter: (UIViewController, DismissingInformation) -> Void = { host, dismissingInfo in
             
             guard let unwrapped = dismissingInfo else { return }
-            host.dismissViewControllerAnimated(unwrapped.animated, completion: unwrapped.completion)
+            host.dismiss(animated: unwrapped.animated, completion: unwrapped.completion)
         }
         
         let property = associatedProperty(self, key: &dismissModally, initial: initial, setter: setter) { property in
-            property <~ self.rac_signalForSelector(#selector(UIViewController.dismissViewControllerAnimated(_:completion:)))
-                .takeUntilBlock { _ in property.value != nil }
+            property <~ self.rac_signal(for: #selector(UIViewController.dismiss))
+                .take { _ in property.value != nil }
                 .rex_toTriggerSignal()
                 .map { _ in return nil }
         }

--- a/Source/UIKit/UIViewController.swift
+++ b/Source/UIKit/UIViewController.swift
@@ -14,36 +14,36 @@ extension UIViewController {
     /// Returns a `Signal`, that will be triggered
     /// when `self`'s `viewDidDisappear` is called
     public var rex_viewDidDisappear: Signal<(), NoError> {
-        return triggerForSelector(#selector(UIViewController.viewDidDisappear(_:)))
+        return trigger(for: #selector(UIViewController.viewDidDisappear(_:)))
     }
-    
+
     /// Returns a `Signal`, that will be triggered
     /// when `self`'s `viewWillDisappear` is called
     public var rex_viewWillDisappear: Signal<(), NoError> {
-        return triggerForSelector(#selector(UIViewController.viewWillDisappear(_:)))
+        return trigger(for: #selector(UIViewController.viewWillDisappear(_:)))
     }
-    
+
     /// Returns a `Signal`, that will be triggered
     /// when `self`'s `viewDidAppear` is called
     public var rex_viewDidAppear: Signal<(), NoError> {
-        return triggerForSelector(#selector(UIViewController.viewDidAppear(_:)))
+        return trigger(for: #selector(UIViewController.viewDidAppear(_:)))
     }
-    
+
     /// Returns a `Signal`, that will be triggered
     /// when `self`'s `viewWillAppear` is called
     public var rex_viewWillAppear: Signal<(), NoError> {
-        return triggerForSelector(#selector(UIViewController.viewWillAppear(_:)))
+        return trigger(for: #selector(UIViewController.viewWillAppear(_:)))
     }
-    
+
     private func trigger(for selector: Selector) -> Signal<(), NoError>  {
         return self
             .rac_signal(for: selector)
             .rex_toTriggerSignal()
     }
-    
+
     public typealias DismissingCompletion = ((Void) -> Void)?
     public typealias DismissingInformation = (animated: Bool, completion: DismissingCompletion)?
-    
+
     /// Wraps a viewController's `dismissViewControllerAnimated` function in a bindable property.
     /// It mimics the same input as `dismissViewControllerAnimated`: a `Bool` flag for the animation
     /// and a `(Void -> Void)?` closure for `completion`.
@@ -55,21 +55,21 @@ extension UIViewController {
     /// The dismissal observation can be made either with binding (example above)
     /// or `viewController.dismissViewControllerAnimated(true, completion: nil)`
     public var rex_dismissAnimated: MutableProperty<DismissingInformation> {
-        
+
         let initial: (UIViewController) -> DismissingInformation = { _ in nil }
         let setter: (UIViewController, DismissingInformation) -> Void = { host, dismissingInfo in
-            
+
             guard let unwrapped = dismissingInfo else { return }
             host.dismiss(animated: unwrapped.animated, completion: unwrapped.completion)
         }
-        
+
         let property = associatedProperty(self, key: &dismissModally, initial: initial, setter: setter) { property in
             property <~ self.rac_signal(for: #selector(UIViewController.dismiss))
                 .take { _ in property.value != nil }
                 .rex_toTriggerSignal()
                 .map { _ in return nil }
         }
-        
+
         return property
     }
 }

--- a/Tests/ActionTests.swift
+++ b/Tests/ActionTests.swift
@@ -13,8 +13,8 @@ import enum Result.NoError
 
 final class ActionTests: XCTestCase {
     
-    enum TestError: ErrorType {
-        case Unknown
+    enum TestError: ErrorProtocol {
+        case unknown
     }
 
     func testStarted() {
@@ -33,7 +33,9 @@ final class ActionTests: XCTestCase {
     }
     
     func testCompleted() {
-        let (producer, observer) = SignalProducer<Int, TestError>.buffer(Int.max)
+        let (signal, observer) = Signal<Int, TestError>.pipe()
+        let producer = SignalProducer(signal: signal)
+
         let action = Action { producer }
 
         var completed = false
@@ -53,7 +55,9 @@ final class ActionTests: XCTestCase {
     }
     
     func testCompletedOnFailed() {
-        let (producer, observer) = SignalProducer<Int, TestError>.buffer(Int.max)
+        let (signal, observer) = Signal<Int, TestError>.pipe()
+        let producer = SignalProducer(signal: signal)
+
         let action = Action { producer }
         
         var completed = false
@@ -65,7 +69,7 @@ final class ActionTests: XCTestCase {
             .apply()
             .start()
         
-        observer.sendFailed(.Unknown)
+        observer.sendFailed(.unknown)
         XCTAssertFalse(completed)
     }
 }

--- a/Tests/ActionTests.swift
+++ b/Tests/ActionTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import Rex
+import ReactiveSwift
 import ReactiveCocoa
 import XCTest
 import enum Result.NoError

--- a/Tests/ActionTests.swift
+++ b/Tests/ActionTests.swift
@@ -13,7 +13,7 @@ import enum Result.NoError
 
 final class ActionTests: XCTestCase {
     
-    enum TestError: ErrorProtocol {
+    enum TestError: Error {
         case unknown
     }
 

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -16,7 +16,7 @@ final class NSObjectTests: XCTestCase {
         let object = Object()
         var value: String = ""
 
-        object.rex_producerForKeyPath("string").startWithNext { value = $0 }
+        object.rex_producer(forKeyPath: "string").startWithNext { value = $0 }
         XCTAssertEqual(value, "foo")
 
         object.string = "bar"

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -25,8 +25,8 @@ final class NSObjectTests: XCTestCase {
     
     func testObjectsWillBeDeallocatedSignal() {
         
-        let expectation = self.expectation(withDescription: "Expected timer to send `completed` event when object deallocates")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected timer to send `completed` event when object deallocates")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let object = Object()
 

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Rex
+import ReactiveSwift
 import ReactiveCocoa
 import XCTest
 

--- a/Tests/Foundation/NSObjectTests.swift
+++ b/Tests/Foundation/NSObjectTests.swift
@@ -25,13 +25,13 @@ final class NSObjectTests: XCTestCase {
     
     func testObjectsWillBeDeallocatedSignal() {
         
-        let expectation = self.expectationWithDescription("Expected timer to send `completed` event when object deallocates")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected timer to send `completed` event when object deallocates")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         let object = Object()
 
-        timer(1, onScheduler: QueueScheduler(name: "test.queue"))
-            .takeUntil(object.rex_willDealloc)
+        timer(interval: 1, on: QueueScheduler(name: "test.queue"))
+            .take(until: object.rex_willDealloc)
             .startWithCompleted {
                 expectation.fulfill()
         }

--- a/Tests/Helpers/UIControl+EnableSendActionsForControlEvents.swift
+++ b/Tests/Helpers/UIControl+EnableSendActionsForControlEvents.swift
@@ -8,6 +8,30 @@
 
 import UIKit
 
+private let rex_swizzleToken: Void = {
+    let originalSelector = #selector(UIControl.sendAction(_:to:for:))
+    let swizzledSelector = #selector(UIControl.rex_sendAction(_:to:forEvent:))
+
+    let originalMethod = class_getInstanceMethod(UIControl.self, originalSelector)
+    let swizzledMethod = class_getInstanceMethod(UIControl.self, swizzledSelector)
+
+    let didAddMethod = class_addMethod(UIControl.self,
+                                       originalSelector,
+                                       method_getImplementation(swizzledMethod),
+                                       method_getTypeEncoding(swizzledMethod))
+
+    if didAddMethod {
+        class_replaceMethod(UIControl.self,
+                            swizzledSelector,
+                            method_getImplementation(originalMethod),
+                            method_getTypeEncoding(originalMethod))
+    } else {
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    return ()
+}()
+
 /// Unfortunately, there's an apparent limitation in using `sendActionsForControlEvents`
 /// on unit-tests for any control besides `UIButton` which is very unfortunate since we
 /// want test our bindings for `UIDatePicker`, `UISwitch`, `UITextField` and others
@@ -16,42 +40,16 @@ import UIKit
 extension UIControl {
 
     public override class func initialize() {
-
-        struct Static {
-            static var token: dispatch_once_t = 0
-        }
-
         if self !== UIControl.self {
             return
         }
 
-        dispatch_once(&Static.token) {
-
-            let originalSelector = #selector(UIControl.sendAction(_:to:forEvent:))
-            let swizzledSelector = #selector(UIControl.rex_sendAction(_:to:forEvent:))
-
-            let originalMethod = class_getInstanceMethod(self, originalSelector)
-            let swizzledMethod = class_getInstanceMethod(self, swizzledSelector)
-
-            let didAddMethod = class_addMethod(self,
-                                               originalSelector,
-                                               method_getImplementation(swizzledMethod),
-                                               method_getTypeEncoding(swizzledMethod))
-
-            if didAddMethod {
-                class_replaceMethod(self,
-                                    swizzledSelector,
-                                    method_getImplementation(originalMethod),
-                                    method_getTypeEncoding(originalMethod))
-            } else {
-                method_exchangeImplementations(originalMethod, swizzledMethod)
-            }
-        }
+        _ = rex_swizzleToken
     }
 
     // MARK: - Method Swizzling
 
-    func rex_sendAction(action: Selector, to target: AnyObject?, forEvent event: UIEvent?) {
-        target?.performSelector(action, withObject: self)
+    func rex_sendAction(_ action: Selector, to target: AnyObject?, forEvent event: UIEvent?) {
+        _ = target?.perform(action, with: self)
     }
 }

--- a/Tests/PropertyTests.swift
+++ b/Tests/PropertyTests.swift
@@ -32,7 +32,7 @@ final class PropertyTests: XCTestCase {
         XCTAssertTrue(current!)
 
         let (signal, pipe) = Signal<Bool, NoError>.pipe()
-        let and2 = and.and(AnyProperty(initial: false, then: signal))
+        let and2 = and.and(Property(initial: false, then: signal))
         and2.producer.startWithNext { current = $0 }
 
         XCTAssertFalse(and2.value)
@@ -62,7 +62,7 @@ final class PropertyTests: XCTestCase {
         XCTAssertFalse(current!)
 
         let (signal, pipe) = Signal<Bool, NoError>.pipe()
-        let or2 = or.or(AnyProperty(initial: true, then: signal))
+        let or2 = or.or(Property(initial: true, then: signal))
         or2.producer.startWithNext { current = $0 }
 
         XCTAssertTrue(or2.value)

--- a/Tests/PropertyTests.swift
+++ b/Tests/PropertyTests.swift
@@ -32,7 +32,7 @@ final class PropertyTests: XCTestCase {
         XCTAssertTrue(current!)
 
         let (signal, pipe) = Signal<Bool, NoError>.pipe()
-        let and2 = and.and(AnyProperty(initialValue: false, signal: signal))
+        let and2 = and.and(AnyProperty(initial: false, then: signal))
         and2.producer.startWithNext { current = $0 }
 
         XCTAssertFalse(and2.value)
@@ -62,7 +62,7 @@ final class PropertyTests: XCTestCase {
         XCTAssertFalse(current!)
 
         let (signal, pipe) = Signal<Bool, NoError>.pipe()
-        let or2 = or.or(AnyProperty(initialValue: true, signal: signal))
+        let or2 = or.or(AnyProperty(initial: true, then: signal))
         or2.producer.startWithNext { current = $0 }
 
         XCTAssertTrue(or2.value)

--- a/Tests/PropertyTests.swift
+++ b/Tests/PropertyTests.swift
@@ -7,6 +7,7 @@
 //
 
 @testable import Rex
+import ReactiveSwift
 import ReactiveCocoa
 import XCTest
 import enum Result.NoError

--- a/Tests/SignalProducerTests.swift
+++ b/Tests/SignalProducerTests.swift
@@ -98,7 +98,7 @@ final class SignalProducerTests: XCTestCase {
         var value = -1
         var completed = false
         producer
-            .deferredRetry(interval: 1, on: scheduler)
+            .deferredRetry(1, on: scheduler)
             .start(Observer(
                 next: { value = $0 },
                 completed: { completed = true }
@@ -136,7 +136,7 @@ final class SignalProducerTests: XCTestCase {
         var value = -1
         var failed = false
         producer
-            .deferredRetry(interval: 1, on: scheduler, count: 2)
+            .deferredRetry(1, on: scheduler, count: 2)
             .start(Observer(
                 next: { value = $0 },
                 failed: { _ in failed = true }

--- a/Tests/SignalProducerTests.swift
+++ b/Tests/SignalProducerTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Rex
+import ReactiveSwift
 import ReactiveCocoa
 import XCTest
 import enum Result.NoError

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -47,7 +47,7 @@ final class SignalTests: XCTestCase {
         observer.sendNext(1)
         XCTAssertFalse(completed)
 
-        observer.sendFailed(.Default)
+        observer.sendFailed(.default)
         XCTAssertTrue(completed)
     }
 
@@ -56,13 +56,13 @@ final class SignalTests: XCTestCase {
         var interrupted = false
 
         signal
-            .ignoreError(replacement: .Interrupted)
+            .ignoreError(replacement: .interrupted)
             .observeInterrupted { interrupted = true }
 
         observer.sendNext(1)
         XCTAssertFalse(interrupted)
 
-        observer.sendFailed(.Default)
+        observer.sendFailed(.default)
         XCTAssertTrue(interrupted)
     }
 
@@ -73,13 +73,13 @@ final class SignalTests: XCTestCase {
         var completed = false
 
         signal
-            .timeoutAfter(2, withEvent: .Interrupted, onScheduler: scheduler)
+            .timeout(after: 2, with: .interrupted, on: scheduler)
             .observe(Observer(
                 completed: { completed = true },
                 interrupted: { interrupted = true }
             ))
 
-        scheduler.scheduleAfter(1) { observer.sendCompleted() }
+        scheduler.schedule(after: 1) { observer.sendCompleted() }
 
         XCTAssertFalse(interrupted)
         XCTAssertFalse(completed)
@@ -96,13 +96,13 @@ final class SignalTests: XCTestCase {
         var completed = false
 
         signal
-            .timeoutAfter(2, withEvent: .Interrupted, onScheduler: scheduler)
+            .timeout(after: 2, with: .interrupted, on: scheduler)
             .observe(Observer(
                 completed: { completed = true },
                 interrupted: { interrupted = true }
             ))
 
-        scheduler.scheduleAfter(3) { observer.sendCompleted() }
+        scheduler.schedule(after: 3) { observer.sendCompleted() }
 
         XCTAssertFalse(interrupted)
         XCTAssertFalse(completed)
@@ -152,7 +152,7 @@ final class SignalTests: XCTestCase {
         scheduler.advance()
         XCTAssertEqual(value, 1)
 
-        scheduler.advanceByInterval(1)
+        scheduler.advance(by: 1)
         XCTAssertEqual(value, 1)
 
         scheduler.schedule { observer.sendNext(5) }
@@ -179,13 +179,13 @@ final class SignalTests: XCTestCase {
         XCTAssertEqual(value, 1)
 
         scheduler.schedule { observer.sendNext(2) }
-        scheduler.schedule { observer.sendFailed(.Default) }
+        scheduler.schedule { observer.sendFailed(.default) }
         scheduler.advance()
         XCTAssertTrue(failed)
         XCTAssertEqual(value, 1)
     }
 }
 
-enum TestError: ErrorType {
-    case Default
+enum TestError: ErrorProtocol {
+    case `default`
 }

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -7,6 +7,7 @@
 //
 
 import Rex
+import ReactiveSwift
 import ReactiveCocoa
 import XCTest
 import enum Result.NoError

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -186,6 +186,6 @@ final class SignalTests: XCTestCase {
     }
 }
 
-enum TestError: ErrorProtocol {
+enum TestError: Error {
     case `default`
 }

--- a/Tests/SignalTests.swift
+++ b/Tests/SignalTests.swift
@@ -136,7 +136,7 @@ final class SignalTests: XCTestCase {
         var value = -1
 
         signal
-            .muteFor(1, clock: scheduler)
+            .mute(for: 1, clock: scheduler)
             .observeNext { value = $0 }
 
         scheduler.schedule { observer.sendNext(1) }
@@ -168,7 +168,7 @@ final class SignalTests: XCTestCase {
         var failed = false
 
         signal
-            .muteFor(1, clock: scheduler)
+            .mute(for: 1, clock: scheduler)
             .observe(Observer(
                 next: { value = $0 },
                 failed: { _ in failed = true }

--- a/Tests/UIKit/UIActivityIndicatorViewTests.swift
+++ b/Tests/UIKit/UIActivityIndicatorViewTests.swift
@@ -20,7 +20,7 @@ class UIActivityIndicatorTests: XCTestCase {
     }
 
     func testAnimatingProperty() {
-        let indicatorView = UIActivityIndicatorView(frame: CGRectZero)
+        let indicatorView = UIActivityIndicatorView(frame: CGRect.zero)
         _activityIndicatorView = indicatorView
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()

--- a/Tests/UIKit/UIActivityIndicatorViewTests.swift
+++ b/Tests/UIKit/UIActivityIndicatorViewTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import ReactiveSwift
 import ReactiveCocoa
 import Result
 

--- a/Tests/UIKit/UIActivityIndicatorViewTests.swift
+++ b/Tests/UIKit/UIActivityIndicatorViewTests.swift
@@ -27,8 +27,8 @@ class UIActivityIndicatorTests: XCTestCase {
         indicatorView.rex_animating <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(true)
-        XCTAssertTrue(indicatorView.isAnimating())
+        XCTAssertTrue(indicatorView.isAnimating)
         observer.sendNext(false)
-        XCTAssertFalse(indicatorView.isAnimating())
+        XCTAssertFalse(indicatorView.isAnimating)
     }
 }

--- a/Tests/UIKit/UIBarButtonItemTests.swift
+++ b/Tests/UIKit/UIBarButtonItemTests.swift
@@ -32,15 +32,15 @@ class UIBarButtonItemTests: XCTestCase {
     
     func testEnabledProperty() {
         let barButtonItem = UIBarButtonItem()
-        barButtonItem.enabled = true
+        barButtonItem.isEnabled = true
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         barButtonItem.rex_enabled <~ SignalProducer(signal: pipeSignal)
         
         
         observer.sendNext(false)
-        XCTAssertFalse(barButtonItem.enabled)
+        XCTAssertFalse(barButtonItem.isEnabled)
         observer.sendNext(true)
-        XCTAssertTrue(barButtonItem.enabled)
+        XCTAssertTrue(barButtonItem.isEnabled)
     }
 }

--- a/Tests/UIKit/UIBarButtonItemTests.swift
+++ b/Tests/UIKit/UIBarButtonItemTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UIButtonTests.swift
+++ b/Tests/UIKit/UIButtonTests.swift
@@ -13,12 +13,12 @@ import enum Result.NoError
 
 extension UIButton {
     static func button() -> UIButton {
-        let button = UIButton(type: UIButtonType.Custom)
+        let button = UIButton(type: UIButtonType.custom)
         return button;
     }
     
-    override public func sendAction(action: Selector, to target: AnyObject?, forEvent event: UIEvent?) {
-        target?.performSelector(action, withObject: nil)
+    override public func sendAction(_ action: Selector, to target: AnyObject?, for event: UIEvent?) {
+        target?.perform(action, with: nil)
     }
 }
 
@@ -32,15 +32,15 @@ class UIButtonTests: XCTestCase {
     }
     
     func testEnabledPropertyDoesntCreateRetainCycle() {
-        let button = UIButton(frame: CGRectZero)
+        let button = UIButton(frame: CGRect.zero)
         _button = button
         
         button.rex_enabled <~ SignalProducer(value: false)
-        XCTAssert(_button?.enabled == false)
+        XCTAssert(_button?.isEnabled == false)
     }
 
     func testPressedPropertyDoesntCreateRetainCycle() {
-        let button = UIButton(frame: CGRectZero)
+        let button = UIButton(frame: CGRect.zero)
         _button = button
 
         let action = Action<(),(),NoError> {
@@ -50,37 +50,37 @@ class UIButtonTests: XCTestCase {
     }
 
     func testTitlePropertyDoesntCreateRetainCycle() {
-        let button = UIButton(frame: CGRectZero)
+        let button = UIButton(frame: CGRect.zero)
         _button = button
 
         button.rex_title <~ SignalProducer(value: "button")
-        XCTAssert(_button?.titleForState(.Normal) == "button")
+        XCTAssert(_button?.title(for: UIControlState()) == "button")
     }
     
     func testTitleProperty() {
         let firstTitle = "First title"
         let secondTitle = "Second title"
-        let button = UIButton(frame: CGRectZero)
+        let button = UIButton(frame: CGRect.zero)
         let (pipeSignal, observer) = Signal<String, NoError>.pipe()
         button.rex_title <~ SignalProducer(signal: pipeSignal)
-        button.setTitle("", forState: .Selected)
-        button.setTitle("", forState: .Highlighted)
+        button.setTitle("", for: .selected)
+        button.setTitle("", for: .highlighted)
         
         observer.sendNext(firstTitle)
-        XCTAssertEqual(button.titleForState(.Normal), firstTitle)
-        XCTAssertEqual(button.titleForState(.Highlighted), "")
-        XCTAssertEqual(button.titleForState(.Selected), "")
+        XCTAssertEqual(button.title(for: UIControlState()), firstTitle)
+        XCTAssertEqual(button.title(for: .highlighted), "")
+        XCTAssertEqual(button.title(for: .selected), "")
         
         observer.sendNext(secondTitle)
-        XCTAssertEqual(button.titleForState(.Normal), secondTitle)
-        XCTAssertEqual(button.titleForState(.Highlighted), "")
-        XCTAssertEqual(button.titleForState(.Selected), "")
+        XCTAssertEqual(button.title(for: UIControlState()), secondTitle)
+        XCTAssertEqual(button.title(for: .highlighted), "")
+        XCTAssertEqual(button.title(for: .selected), "")
     }
     
     func testPressedProperty() {
-        let button = UIButton(frame: CGRectZero)
-        button.enabled = true
-        button.userInteractionEnabled = true
+        let button = UIButton(frame: CGRect.zero)
+        button.isEnabled = true
+        button.isUserInteractionEnabled = true
 
         let passed = MutableProperty(false)
         let action = Action<(), Bool, NoError> { _ in
@@ -90,7 +90,7 @@ class UIButtonTests: XCTestCase {
         passed <~ SignalProducer(signal: action.values)
         button.rex_pressed <~ SignalProducer(value: CocoaAction(action, input: ()))
         
-        button.sendActionsForControlEvents(.TouchUpInside)
+        button.sendActions(for: .touchUpInside)
         
         
         XCTAssertTrue(passed.value)

--- a/Tests/UIKit/UIButtonTests.swift
+++ b/Tests/UIKit/UIButtonTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UICollectionReusableViewTests.swift
+++ b/Tests/UIKit/UICollectionReusableViewTests.swift
@@ -7,8 +7,8 @@
 //
 
 import XCTest
+import ReactiveSwift
 import ReactiveCocoa
-
 class UICollectionReusableViewTests: XCTestCase {
     
     func testPrepareForReuse() {

--- a/Tests/UIKit/UICollectionReusableViewTests.swift
+++ b/Tests/UIKit/UICollectionReusableViewTests.swift
@@ -20,16 +20,16 @@ class UICollectionReusableViewTests: XCTestCase {
         cell.rex_hidden <~
             hiddenProperty
                 .producer
-                .takeUntil(cell.rex_prepareForReuse)
+                .take(until: cell.rex_prepareForReuse)
 
-        XCTAssertFalse(cell.hidden)
+        XCTAssertFalse(cell.isHidden)
 
         hiddenProperty <~ SignalProducer(value: true)
-        XCTAssertTrue(cell.hidden)
+        XCTAssertTrue(cell.isHidden)
 
         cell.prepareForReuse()
 
         hiddenProperty <~ SignalProducer(value: false)
-        XCTAssertTrue(cell.hidden)
+        XCTAssertTrue(cell.isHidden)
     }
 }

--- a/Tests/UIKit/UIControlTests.swift
+++ b/Tests/UIKit/UIControlTests.swift
@@ -21,72 +21,72 @@ class UIControlTests: XCTestCase {
     }
     
     func testEnabledPropertyDoesntCreateRetainCycle() {
-        let control = UIControl(frame: CGRectZero)
+        let control = UIControl(frame: CGRect.zero)
         _control = control
         
         control.rex_enabled <~ SignalProducer(value: false)
-        XCTAssert(_control?.enabled == false)
+        XCTAssert(_control?.isEnabled == false)
     }
     
     func testSelectedPropertyDoesntCreateRetainCycle() {
-        let control = UIControl(frame: CGRectZero)
+        let control = UIControl(frame: CGRect.zero)
         _control = control
         
         control.rex_selected <~ SignalProducer(value: true)
-        XCTAssert(_control?.selected == true)
+        XCTAssert(_control?.isSelected == true)
     }
     
     func testHighlightedPropertyDoesntCreateRetainCycle() {
-        let control = UIControl(frame: CGRectZero)
+        let control = UIControl(frame: CGRect.zero)
         _control = control
         
         control.rex_highlighted <~ SignalProducer(value: true)
-        XCTAssert(_control?.highlighted == true)
+        XCTAssert(_control?.isHighlighted == true)
     }
     
     func testEnabledProperty () {
-        let control = UIControl(frame: CGRectZero)
-        control.enabled = false
+        let control = UIControl(frame: CGRect.zero)
+        control.isEnabled = false
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         control.rex_enabled <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(true)
-        XCTAssertTrue(control.enabled)
+        XCTAssertTrue(control.isEnabled)
         observer.sendNext(false)
-        XCTAssertFalse(control.enabled)
+        XCTAssertFalse(control.isEnabled)
     }
     
     func testSelectedProperty() {
-        let control = UIControl(frame: CGRectZero)
-        control.selected = false
+        let control = UIControl(frame: CGRect.zero)
+        control.isSelected = false
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         control.rex_selected <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(true)
-        XCTAssertTrue(control.selected)
+        XCTAssertTrue(control.isSelected)
         observer.sendNext(false)
-        XCTAssertFalse(control.selected)
+        XCTAssertFalse(control.isSelected)
     }
     
     func testHighlightedProperty() {
-        let control = UIControl(frame: CGRectZero)
-        control.highlighted = false
+        let control = UIControl(frame: CGRect.zero)
+        control.isHighlighted = false
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         control.rex_highlighted <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(true)
-        XCTAssertTrue(control.highlighted)
+        XCTAssertTrue(control.isHighlighted)
         observer.sendNext(false)
-        XCTAssertFalse(control.highlighted)
+        XCTAssertFalse(control.isHighlighted)
     }
     
     func testEnabledAndSelectedProperty() {
-        let control = UIControl(frame: CGRectZero)
-        control.selected = false
-        control.enabled = false
+        let control = UIControl(frame: CGRect.zero)
+        control.isSelected = false
+        control.isEnabled = false
         
         let (pipeSignalSelected, observerSelected) = Signal<Bool, NoError>.pipe()
         let (pipeSignalEnabled, observerEnabled) = Signal<Bool, NoError>.pipe()
@@ -95,13 +95,13 @@ class UIControlTests: XCTestCase {
         
         observerSelected.sendNext(true)
         observerEnabled.sendNext(true)
-        XCTAssertTrue(control.enabled)
-        XCTAssertTrue(control.selected)
+        XCTAssertTrue(control.isEnabled)
+        XCTAssertTrue(control.isSelected)
         observerSelected.sendNext(false)
-        XCTAssertTrue(control.enabled)
-        XCTAssertFalse(control.selected)
+        XCTAssertTrue(control.isEnabled)
+        XCTAssertFalse(control.isSelected)
         observerEnabled.sendNext(false)
-        XCTAssertFalse(control.enabled)
-        XCTAssertFalse(control.selected)
+        XCTAssertFalse(control.isEnabled)
+        XCTAssertFalse(control.isSelected)
     }
 }

--- a/Tests/UIKit/UIControlTests.swift
+++ b/Tests/UIKit/UIControlTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UIDatePickerTests.swift
+++ b/Tests/UIKit/UIDatePickerTests.swift
@@ -31,8 +31,8 @@ class UIDatePickerTests: XCTestCase {
     }
 
     func testUpdatePropertyFromPicker() {
-        let expectation = self.expectation(withDescription: "Expected rex_date to send an event when picker's date value is changed by a UI event")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_date to send an event when picker's date value is changed by a UI event")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         picker.rex_date.signal.observeNext { changedDate in
             XCTAssertEqual(changedDate, self.date)

--- a/Tests/UIKit/UIDatePickerTests.swift
+++ b/Tests/UIKit/UIDatePickerTests.swift
@@ -13,15 +13,15 @@ import Rex
 
 class UIDatePickerTests: XCTestCase {
     
-    var date: NSDate!
+    var date: Date!
     var picker: UIDatePicker!
     
     override func setUp() {
-        let formatter = NSDateFormatter()
+        let formatter = DateFormatter()
         formatter.dateFormat = "MM/dd/YYYY"
-        date = formatter.dateFromString("11/29/1988")!
+        date = formatter.date(from: "11/29/1988")!
         
-        picker = UIDatePicker(frame: CGRectZero)
+        picker = UIDatePicker(frame: CGRect.zero)
     }
     
     func testUpdatePickerFromProperty() {
@@ -31,8 +31,8 @@ class UIDatePickerTests: XCTestCase {
     }
 
     func testUpdatePropertyFromPicker() {
-        let expectation = self.expectationWithDescription("Expected rex_date to send an event when picker's date value is changed by a UI event")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_date to send an event when picker's date value is changed by a UI event")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         picker.rex_date.signal.observeNext { changedDate in
             XCTAssertEqual(changedDate, self.date)
@@ -40,8 +40,8 @@ class UIDatePickerTests: XCTestCase {
         }
         
         picker.date = date
-        picker.enabled = true
-        picker.userInteractionEnabled = true
-        picker.sendActionsForControlEvents(.ValueChanged)
+        picker.isEnabled = true
+        picker.isUserInteractionEnabled = true
+        picker.sendActions(for: .valueChanged)
     }
 }

--- a/Tests/UIKit/UIDatePickerTests.swift
+++ b/Tests/UIKit/UIDatePickerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UIImageViewTests.swift
+++ b/Tests/UIKit/UIImageViewTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UIImageViewTests.swift
+++ b/Tests/UIKit/UIImageViewTests.swift
@@ -21,7 +21,7 @@ class UIImageViewTests: XCTestCase {
     }
     
     func testImagePropertyDoesntCreateRetainCycle() {
-        let imageView = UIImageView(frame: CGRectZero)
+        let imageView = UIImageView(frame: CGRect.zero)
         _imageView = imageView
         
         let image = UIImage()
@@ -31,7 +31,7 @@ class UIImageViewTests: XCTestCase {
     }
     
     func testHighlightedImagePropertyDoesntCreateRetainCycle() {
-        let imageView = UIImageView(frame: CGRectZero)
+        let imageView = UIImageView(frame: CGRect.zero)
         _imageView = imageView
         
         let image = UIImage()
@@ -41,7 +41,7 @@ class UIImageViewTests: XCTestCase {
     }
     
     func testImageProperty() {
-        let imageView = UIImageView(frame: CGRectZero)
+        let imageView = UIImageView(frame: CGRect.zero)
         
         let firstChange = UIImage()
         let secondChange = UIImage()
@@ -56,7 +56,7 @@ class UIImageViewTests: XCTestCase {
     }
     
     func testHighlightedImageProperty() {
-        let imageView = UIImageView(frame: CGRectZero)
+        let imageView = UIImageView(frame: CGRect.zero)
         
         let firstChange = UIImage()
         let secondChange = UIImage()

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -50,18 +50,18 @@ class UILabelTests: XCTestCase {
         let label = UILabel(frame: CGRect.zero)
         _label = label
         
-        label.rex_attributedText <~ SignalProducer(value: AttributedString(string: "Test"))
+        label.rex_attributedText <~ SignalProducer(value: NSAttributedString(string: "Test"))
         XCTAssert(_label?.attributedText?.string == "Test")
     }
     
     func testAttributedTextProperty() {
-        let firstChange = AttributedString(string: "first")
-        let secondChange = AttributedString(string: "second")
+        let firstChange = NSAttributedString(string: "first")
+        let secondChange = NSAttributedString(string: "second")
         
         let label = UILabel(frame: CGRect.zero)
-        label.attributedText = AttributedString(string: "")
+        label.attributedText = NSAttributedString(string: "")
         
-        let (pipeSignal, observer) = Signal<AttributedString?, NoError>.pipe()
+        let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
         label.rex_attributedText <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(firstChange)

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -21,7 +21,7 @@ class UILabelTests: XCTestCase {
     }
 
     func testTextPropertyDoesntCreateRetainCycle() {
-        let label = UILabel(frame: CGRectZero)
+        let label = UILabel(frame: CGRect.zero)
         _label = label
 
         label.rex_text <~ SignalProducer(value: "Test")
@@ -32,7 +32,7 @@ class UILabelTests: XCTestCase {
         let firstChange = "first"
         let secondChange = "second"
         
-        let label = UILabel(frame: CGRectZero)
+        let label = UILabel(frame: CGRect.zero)
         label.text = ""
         
         let (pipeSignal, observer) = Signal<String?, NoError>.pipe()
@@ -47,21 +47,21 @@ class UILabelTests: XCTestCase {
     }
     
     func testAttributedTextPropertyDoesntCreateRetainCycle() {
-        let label = UILabel(frame: CGRectZero)
+        let label = UILabel(frame: CGRect.zero)
         _label = label
         
-        label.rex_attributedText <~ SignalProducer(value: NSAttributedString(string: "Test"))
+        label.rex_attributedText <~ SignalProducer(value: AttributedString(string: "Test"))
         XCTAssert(_label?.attributedText?.string == "Test")
     }
     
     func testAttributedTextProperty() {
-        let firstChange = NSAttributedString(string: "first")
-        let secondChange = NSAttributedString(string: "second")
+        let firstChange = AttributedString(string: "first")
+        let secondChange = AttributedString(string: "second")
         
-        let label = UILabel(frame: CGRectZero)
-        label.attributedText = NSAttributedString(string: "")
+        let label = UILabel(frame: CGRect.zero)
+        label.attributedText = AttributedString(string: "")
         
-        let (pipeSignal, observer) = Signal<NSAttributedString?, NoError>.pipe()
+        let (pipeSignal, observer) = Signal<AttributedString?, NoError>.pipe()
         label.rex_attributedText <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(firstChange)
@@ -71,13 +71,13 @@ class UILabelTests: XCTestCase {
     }
     
     func testTextColorProperty() {
-        let firstChange = UIColor.redColor()
-        let secondChange = UIColor.blackColor()
+        let firstChange = UIColor.red()
+        let secondChange = UIColor.black()
         
-        let label = UILabel(frame: CGRectZero)
+        let label = UILabel(frame: CGRect.zero)
 
         let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
-        label.textColor = UIColor.blackColor()
+        label.textColor = UIColor.black()
         label.rex_textColor <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(firstChange)

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -71,13 +71,13 @@ class UILabelTests: XCTestCase {
     }
     
     func testTextColorProperty() {
-        let firstChange = UIColor.red()
-        let secondChange = UIColor.black()
+        let firstChange = UIColor.red
+        let secondChange = UIColor.black
         
         let label = UILabel(frame: CGRect.zero)
 
         let (pipeSignal, observer) = Signal<UIColor, NoError>.pipe()
-        label.textColor = UIColor.black()
+        label.textColor = UIColor.black
         label.rex_textColor <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(firstChange)

--- a/Tests/UIKit/UILabelTests.swift
+++ b/Tests/UIKit/UILabelTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UIProgressViewTests.swift
+++ b/Tests/UIKit/UIProgressViewTests.swift
@@ -20,7 +20,7 @@ class UIProgressViewTests: XCTestCase {
     }
     
     func testProgressPropertyDoesntCreateRetainCycle() {
-        let progressView = UIProgressView(frame: CGRectZero)
+        let progressView = UIProgressView(frame: CGRect.zero)
         _progressView = progressView
         
         progressView.rex_progress <~ SignalProducer(value: 0.5)
@@ -31,7 +31,7 @@ class UIProgressViewTests: XCTestCase {
         let firstChange: Float = 0.5
         let secondChange: Float = 0.0
         
-        let progressView = UIProgressView(frame: CGRectZero)
+        let progressView = UIProgressView(frame: CGRect.zero)
         progressView.progress = 1.0
         
         let (pipeSignal, observer) = Signal<Float, NoError>.pipe()

--- a/Tests/UIKit/UIProgressViewTests.swift
+++ b/Tests/UIKit/UIProgressViewTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UISegmentedControlTests.swift
+++ b/Tests/UIKit/UISegmentedControlTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import ReactiveSwift
 import ReactiveCocoa
 import Result
 

--- a/Tests/UIKit/UISwitchTests.swift
+++ b/Tests/UIKit/UISwitchTests.swift
@@ -13,19 +13,19 @@ import Result
 class UISwitchTests: XCTestCase {
     
     func testOnProperty() {
-        let `switch` = UISwitch(frame: CGRectZero)
-        `switch`.on = false
+        let `switch` = UISwitch(frame: CGRect.zero)
+        `switch`.isOn = false
 
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         `switch`.rex_on <~ SignalProducer(signal: pipeSignal)
 
         observer.sendNext(true)
-        XCTAssertTrue(`switch`.on)
+        XCTAssertTrue(`switch`.isOn)
         observer.sendNext(false)
-        XCTAssertFalse(`switch`.on)
+        XCTAssertFalse(`switch`.isOn)
 
-        `switch`.on = true
-        `switch`.sendActionsForControlEvents(.ValueChanged)
+        `switch`.isOn = true
+        `switch`.sendActions(for: .valueChanged)
         XCTAssertTrue(`switch`.rex_on.value)
     }
 }

--- a/Tests/UIKit/UISwitchTests.swift
+++ b/Tests/UIKit/UISwitchTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import ReactiveSwift
 import ReactiveCocoa
 import Result
 

--- a/Tests/UIKit/UITableViewCellTests.swift
+++ b/Tests/UIKit/UITableViewCellTests.swift
@@ -24,8 +24,7 @@ class UITableViewCellTests: XCTestCase {
         label.rex_text <~
             titleProperty
                 .producer
-                .map(Optional.init) // TODO: Remove in the future, binding with optionals will be available soon in RAC 5. Reference: https://github.com/ReactiveCocoa/ReactiveCocoa/pull/2852
-                .takeUntil(cell.rex_prepareForReuse)
+                .take(until: cell.rex_prepareForReuse)
 
         XCTAssertEqual(label.text, "John")
 

--- a/Tests/UIKit/UITableViewCellTests.swift
+++ b/Tests/UIKit/UITableViewCellTests.swift
@@ -7,8 +7,8 @@
 //
 
 import XCTest
+import ReactiveSwift
 import ReactiveCocoa
-
 class UITableViewCellTests: XCTestCase {
     
     func testPrepareForReuse() {

--- a/Tests/UIKit/UITableViewHeaderFooterViewTests.swift
+++ b/Tests/UIKit/UITableViewHeaderFooterViewTests.swift
@@ -20,16 +20,16 @@ class UITableViewHeaderFooterViewTests: XCTestCase {
         header.rex_hidden <~
             hiddenProperty
                 .producer
-                .takeUntil(header.rex_prepareForReuse)
+                .take(until: header.rex_prepareForReuse)
 
-        XCTAssertFalse(header.hidden)
+        XCTAssertFalse(header.isHidden)
 
         hiddenProperty <~ SignalProducer(value: true)
-        XCTAssertTrue(header.hidden)
+        XCTAssertTrue(header.isHidden)
 
         header.prepareForReuse()
 
         hiddenProperty <~ SignalProducer(value: false)
-        XCTAssertTrue(header.hidden)
+        XCTAssertTrue(header.isHidden)
     }
 }

--- a/Tests/UIKit/UITableViewHeaderFooterViewTests.swift
+++ b/Tests/UIKit/UITableViewHeaderFooterViewTests.swift
@@ -7,8 +7,8 @@
 //
 
 import XCTest
+import ReactiveSwift
 import ReactiveCocoa
-
 class UITableViewHeaderFooterViewTests: XCTestCase {
     
     func testPrepareForReuse() {

--- a/Tests/UIKit/UITextFieldTests.swift
+++ b/Tests/UIKit/UITextFieldTests.swift
@@ -27,7 +27,7 @@ class UITextFieldTests: XCTestCase {
 #if os(iOS)
         textField.sendActions(for: .editingChanged)
 #else
-        NSNotificationCenter.defaultCenter().postNotificationName(UITextFieldTextDidChangeNotification, object: textField)
+        NotificationCenter.default.post(name: .UITextFieldTextDidChange, object: textField)
 #endif
     }
 }

--- a/Tests/UIKit/UITextFieldTests.swift
+++ b/Tests/UIKit/UITextFieldTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UITextFieldTests.swift
+++ b/Tests/UIKit/UITextFieldTests.swift
@@ -13,8 +13,8 @@ import XCTest
 class UITextFieldTests: XCTestCase {
 
     func testTextProperty() {
-        let expectation = self.expectation(withDescription: "Expected `rex_text`'s value to equal to the textField's text")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected `rex_text`'s value to equal to the textField's text")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
 
         let textField = UITextField(frame: CGRect.zero)
         textField.text = "Test"

--- a/Tests/UIKit/UITextFieldTests.swift
+++ b/Tests/UIKit/UITextFieldTests.swift
@@ -13,10 +13,10 @@ import XCTest
 class UITextFieldTests: XCTestCase {
 
     func testTextProperty() {
-        let expectation = self.expectationWithDescription("Expected `rex_text`'s value to equal to the textField's text")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected `rex_text`'s value to equal to the textField's text")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
 
-        let textField = UITextField(frame: CGRectZero)
+        let textField = UITextField(frame: CGRect.zero)
         textField.text = "Test"
         
         textField.rex_text.signal.observeNext { text in
@@ -25,7 +25,7 @@ class UITextFieldTests: XCTestCase {
         }
 
 #if os(iOS)
-        textField.sendActionsForControlEvents(.EditingChanged)
+        textField.sendActions(for: .editingChanged)
 #else
         NSNotificationCenter.defaultCenter().postNotificationName(UITextFieldTextDidChangeNotification, object: textField)
 #endif

--- a/Tests/UIKit/UITextViewTests.swift
+++ b/Tests/UIKit/UITextViewTests.swift
@@ -13,8 +13,8 @@ import XCTest
 class UITextViewTests: XCTestCase {
     
     func testTextProperty() {
-        let expectation = self.expectation(withDescription: "Expected `rex_text`'s value to equal to the textViews's text")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected `rex_text`'s value to equal to the textViews's text")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let textView = UITextView(frame: CGRect.zero)
         textView.text = "Test"

--- a/Tests/UIKit/UITextViewTests.swift
+++ b/Tests/UIKit/UITextViewTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UITextViewTests.swift
+++ b/Tests/UIKit/UITextViewTests.swift
@@ -13,10 +13,10 @@ import XCTest
 class UITextViewTests: XCTestCase {
     
     func testTextProperty() {
-        let expectation = self.expectationWithDescription("Expected `rex_text`'s value to equal to the textViews's text")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected `rex_text`'s value to equal to the textViews's text")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
-        let textView = UITextView(frame: CGRectZero)
+        let textView = UITextView(frame: CGRect.zero)
         textView.text = "Test"
         
         textView.rex_text.startWithNext { text in
@@ -24,6 +24,6 @@ class UITextViewTests: XCTestCase {
             expectation.fulfill()
         }
         
-        NSNotificationCenter.defaultCenter().postNotificationName(UITextViewTextDidChangeNotification, object: textView)
+        NotificationCenter.default.post(name: NSNotification.Name.UITextViewTextDidChange, object: textView)
     }
 }

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -22,8 +22,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewDidDisappear() {
         
-        let expectation = self.expectation(withDescription: "Expected rex_viewDidDisappear to be triggered")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_viewDidDisappear to be triggered")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
 
         let viewController = UIViewController()
         _viewController = viewController
@@ -37,8 +37,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewWillDisappear() {
         
-        let expectation = self.expectation(withDescription: "Expected rex_viewWillDisappear to be triggered")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_viewWillDisappear to be triggered")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -52,8 +52,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewDidAppear() {
         
-        let expectation = self.expectation(withDescription: "Expected rex_viewDidAppear to be triggered")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_viewDidAppear to be triggered")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -67,8 +67,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewWillAppear() {
         
-        let expectation = self.expectation(withDescription: "Expected rex_viewWillAppear to be triggered")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_viewWillAppear to be triggered")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -82,8 +82,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testDismissViewController_via_property() {
         
-        let expectation = self.expectation(withDescription: "Expected rex_dismissModally to be triggered")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_dismissModally to be triggered")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -97,8 +97,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testDismissViewController_via_cocoaDismiss() {
         
-        let expectation = self.expectation(withDescription: "Expected rex_dismissModally to be triggered")
-        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
+        let expectation = self.expectation(description: "Expected rex_dismissModally to be triggered")
+        defer { self.waitForExpectations(timeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/Tests/UIKit/UIViewControllerTests.swift
+++ b/Tests/UIKit/UIViewControllerTests.swift
@@ -22,8 +22,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewDidDisappear() {
         
-        let expectation = self.expectationWithDescription("Expected rex_viewDidDisappear to be triggered")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_viewDidDisappear to be triggered")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
 
         let viewController = UIViewController()
         _viewController = viewController
@@ -37,8 +37,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewWillDisappear() {
         
-        let expectation = self.expectationWithDescription("Expected rex_viewWillDisappear to be triggered")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_viewWillDisappear to be triggered")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -52,8 +52,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewDidAppear() {
         
-        let expectation = self.expectationWithDescription("Expected rex_viewDidAppear to be triggered")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_viewDidAppear to be triggered")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -67,8 +67,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testViewWillAppear() {
         
-        let expectation = self.expectationWithDescription("Expected rex_viewWillAppear to be triggered")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_viewWillAppear to be triggered")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -82,8 +82,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testDismissViewController_via_property() {
         
-        let expectation = self.expectationWithDescription("Expected rex_dismissModally to be triggered")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_dismissModally to be triggered")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -97,8 +97,8 @@ class UIViewControllerTests: XCTestCase {
     
     func testDismissViewController_via_cocoaDismiss() {
         
-        let expectation = self.expectationWithDescription("Expected rex_dismissModally to be triggered")
-        defer { self.waitForExpectationsWithTimeout(2, handler: nil) }
+        let expectation = self.expectation(withDescription: "Expected rex_dismissModally to be triggered")
+        defer { self.waitForExpectations(withTimeout: 2, handler: nil) }
         
         let viewController = UIViewController()
         _viewController = viewController
@@ -107,6 +107,6 @@ class UIViewControllerTests: XCTestCase {
             expectation.fulfill()
         }
 
-        viewController.dismissViewControllerAnimated(true, completion: nil)
+        viewController.dismiss(animated: true, completion: nil)
     }
 }

--- a/Tests/UIKit/UIViewTests.swift
+++ b/Tests/UIKit/UIViewTests.swift
@@ -21,7 +21,7 @@ class UIViewTests: XCTestCase {
     }
     
     func testAlphaPropertyDoesntCreateRetainCycle() {
-        let view = UIView(frame: CGRectZero)
+        let view = UIView(frame: CGRect.zero)
         _view = view
         
         view.rex_alpha <~ SignalProducer(value: 0.5)
@@ -29,28 +29,28 @@ class UIViewTests: XCTestCase {
     }
     
     func testHiddenPropertyDoesntCreateRetainCycle() {
-        let view = UIView(frame: CGRectZero)
+        let view = UIView(frame: CGRect.zero)
         _view = view
         
         view.rex_hidden <~ SignalProducer(value: true)
-        XCTAssert(_view?.hidden == true)
+        XCTAssert(_view?.isHidden == true)
     }
     
     func testHiddenProperty() {
-        let view = UIView(frame: CGRectZero)
-        view.hidden = true
+        let view = UIView(frame: CGRect.zero)
+        view.isHidden = true
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         view.rex_hidden <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(true)
-        XCTAssertTrue(view.hidden)
+        XCTAssertTrue(view.isHidden)
         observer.sendNext(false)
-        XCTAssertFalse(view.hidden)
+        XCTAssertFalse(view.isHidden)
     }
     
     func testAlphaProperty() {
-        let view = UIView(frame: CGRectZero)
+        let view = UIView(frame: CGRect.zero)
         view.alpha = 0.0
         
         let firstChange = CGFloat(0.5)
@@ -66,15 +66,15 @@ class UIViewTests: XCTestCase {
     }
     
     func testUserInteractionEnabledProperty() {
-        let view = UIView(frame: CGRectZero)
-        view.userInteractionEnabled = true
+        let view = UIView(frame: CGRect.zero)
+        view.isUserInteractionEnabled = true
         
         let (pipeSignal, observer) = Signal<Bool, NoError>.pipe()
         view.rex_userInteractionEnabled <~ SignalProducer(signal: pipeSignal)
         
         observer.sendNext(true)
-        XCTAssertTrue(view.userInteractionEnabled)
+        XCTAssertTrue(view.isUserInteractionEnabled)
         observer.sendNext(false)
-        XCTAssertFalse(view.userInteractionEnabled)
+        XCTAssertFalse(view.isUserInteractionEnabled)
     }
 }

--- a/Tests/UIKit/UIViewTests.swift
+++ b/Tests/UIKit/UIViewTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Neil Pankey. All rights reserved.
 //
 
+import ReactiveSwift
 import ReactiveCocoa
 import UIKit
 import XCTest

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+set -e -o pipefail
+
+bootstrap() {
+  case "$1" in
+    CocoaPods)
+      ;;
+    *)
+      carthage bootstrap --no-use-binaries --platform "$1"
+      ;;
+  esac
+}
+
+build() {
+  case "$1" in
+    Mac)
+      xcodebuild ${TEST_ACTION:-test} -scheme Rex-Mac | xcpretty -c
+      ;;
+    iOS)
+      xcodebuild ${TEST_ACTION:-test} -scheme Rex-iOS -destination "platform=iOS Simulator,name=iPhone 6s" | xcpretty -c
+      ;;
+    tvOS)
+      xcodebuild ${TEST_ACTION:-test} -scheme Rex-tvOS -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty -c
+      ;;
+    watchOS)
+      xcodebuild build -scheme Rex-watchOS -destination "platform=watchOS Simulator,name=Apple Watch - 42mm" | xcpretty -c
+      ;;
+    CocoaPods)
+      pod lib lint --quick --allow-warnings
+      ;;
+    *)
+      echo 2>&1 "Usage: $0 <Mac|iOS|tvOS|watchOS|CocoaPods>"
+      exit 1
+      ;;
+  esac
+}
+
+bootstrap "$@"
+build "$@"


### PR DESCRIPTION
Previously #142.
Depends on ReactiveCocoa's `RAC5` branch for Swift 3.0.
